### PR TITLE
Fixed README.md wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ openstack.net
 
 .Net SDK and client side utilities for common openstack providers
 
-You can view our documentation in our <a href="https://github.com/alanquillin/openstack.net/wiki">Wiki</a>.
+You can view our documentation in our <a href="https://github.com/rackspace/openstack.net/wiki">Wiki</a>.


### PR DESCRIPTION
The README linked to the old repo's wiki.
