### PR TITLE
[Delivers #43555145]Copy object functionality

### DIFF
--- a/src/corelib/Core/Domain/ObjectStore.cs
+++ b/src/corelib/Core/Domain/ObjectStore.cs
@@ -13,6 +13,7 @@ namespace net.openstack.Core.Domain
         ContainerDeleted,
         ContainerNotEmpty,
         ContainerNotFound,
-        ObjectDeleted
+        ObjectDeleted,
+        ObjectCreated
     }
 }

--- a/src/corelib/Core/IObjectStoreProvider.cs
+++ b/src/corelib/Core/IObjectStoreProvider.cs
@@ -45,6 +45,7 @@ namespace net.openstack.Core
         void GetObjectSaveToFile(string container, string saveDirectory, string objectName, string fileName = null, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, bool verifyEtag = false, CloudIdentity identity = null);
         void GetObject(string container, string objectName, Stream outputStream, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, bool verifyEtag = false, CloudIdentity identity = null);
         ObjectStore DeleteObject(CloudIdentity identity, string container, string objectNmae, Dictionary<string, string> headers = null, string region = null);
+        ObjectStore CopyObject(CloudIdentity identity, string sourceContainer, string sourceObjectName, string destinationContainer, string destinationObjectName, Dictionary<string, string> headers = null, string region = null);
 
         #endregion
 

--- a/src/corelib/Providers/Rackspace/ObjectStoreConstants.cs
+++ b/src/corelib/Providers/Rackspace/ObjectStoreConstants.cs
@@ -40,6 +40,7 @@ namespace net.openstack.Providers.Rackspace
         public const string Etag = "etag";
         public const string ContentType = "content-type";
         public const string ContentLength = "content-length";
+        public const string CopyFrom = "x-copy-from";
         //Cdn Object Constants
         public const string CdnPurgeEmail = "x-purge-email";
         //Misc Headers

--- a/src/testing/integration/Providers/Rackspace/ObjectStoreTests.cs
+++ b/src/testing/integration/Providers/Rackspace/ObjectStoreTests.cs
@@ -554,6 +554,61 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
 
             Assert.Fail("Expected exception was not thrown.");
         }
+
+        [TestMethod]
+        public void Should_Copy_Object_When_Not_Passing_Content_Length()
+        {
+            const string sourceContainerName = "DarkKnight";
+            const string sourceObjectName = "BatmanBegins.jpg";
+
+            const string destinationContainerName = "rk_test";
+            const string destinationObjectName = "BatmanBegins.jpg";
+            
+            var provider = new ObjectStoreProvider();
+            var copyResponse = provider.CopyObject(_testIdentity, sourceContainerName, sourceObjectName, destinationContainerName,destinationObjectName);
+
+            Assert.AreEqual(ObjectStore.ObjectCreated, copyResponse);
+        }
+        
+        [TestMethod]
+        public void Should_Copy_Object_When_Passing_Content_Length()
+        {
+            const string sourceContainerName = "DarkKnight";
+            const string sourceObjectName = "BatmanBegins.jpg";
+
+            const string destinationContainerName = "rk_test";
+            const string destinationObjectName = "BatmanBegins.jpg";
+
+            Dictionary<string,string> header = new Dictionary<string, string>();
+            header.Add(ObjectStoreConstants.ContentLength, "62504");
+            
+            var provider = new ObjectStoreProvider();
+            var copyResponse = provider.CopyObject(_testIdentity, sourceContainerName, sourceObjectName, destinationContainerName,destinationObjectName,header);
+
+            Assert.AreEqual(ObjectStore.ObjectCreated, copyResponse);
+        }
+
+        [TestMethod]
+        public void Should_Copy_Object_When_Not_Passing_Content_Length_And_Passing_Expiring_Header()
+        {
+            // Object will expire 2 days from now.
+            int epoch = (int)(DateTime.UtcNow.AddDays(2) - new DateTime(1970, 1, 1)).TotalSeconds;
+            const string sourceContainerName = "DarkKnight";
+            const string sourceObjectName = "BatmanBegins.jpg";
+
+            const string destinationContainerName = "rk_test";
+            const string destinationObjectName = "BatmanBegins.jpg";
+
+            Dictionary<string, string> header = new Dictionary<string, string>();
+            header.Add(ObjectStoreConstants.ObjectDeleteAt, epoch.ToString());
+
+            var provider = new ObjectStoreProvider();
+            var copyResponse = provider.CopyObject(_testIdentity, sourceContainerName, sourceObjectName, destinationContainerName, destinationObjectName, header);
+
+            Assert.AreEqual(ObjectStore.ObjectCreated, copyResponse);
+
+        }
+
         #endregion Object Tests
 
     }


### PR DESCRIPTION
Copy object from one container to another, since content-length is required, if user doesn't pass content-length, we will try to get content-length by making a call to GetObjectHeaders.
