### PR TITLE
Update the ObjectStoreProvider's CreateObjectFromFile to open stream and wrap usage in a using statement to ensure disposing of the stream

### DIFF
--- a/src/corelib/Core/IObjectStoreProvider.cs
+++ b/src/corelib/Core/IObjectStoreProvider.cs
@@ -42,10 +42,8 @@ namespace net.openstack.Core
         #region Container Objects
 
         IEnumerable<ContainerObject> GetObjects(CloudIdentity identity, string container, int? limit = null, string markerId = null, string markerEnd = null, string format = "json", string region = null);
-        void CreateObjectFromFile(CloudIdentity identity, string container, string filePath, string objectName, int chunkSize = 65536, string region = null, Action<long> progressUpdated = null);
-        void CreateObjectFromFile(CloudIdentity identity, string container, string filePath, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null);
-        void CreateObjectFromStream(CloudIdentity identity, string container, Stream stream, string objectName, int chunkSize = 65536, string region = null, Action<long> progressUpdated = null);
-        void CreateObjectFromStream(CloudIdentity identity, string container, Stream stream, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null);
+        void CreateObjectFromFile(string container, string filePath, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null, CloudIdentity identity = null);
+        void CreateObjectFromStream(string container, Stream stream, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null, CloudIdentity identity = null);
         void GetObjectSaveToFile(string container, string saveDirectory, string objectName, string fileName = null, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, bool verifyEtag = false, CloudIdentity identity = null);
         void GetObject(string container, string objectName, Stream outputStream, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, bool verifyEtag = false, CloudIdentity identity = null);
         ObjectStore DeleteObject(CloudIdentity identity, string container, string objectNmae, Dictionary<string, string> headers = null, string region = null);

--- a/src/corelib/Providers/Rackspace/ComputeProvider.cs
+++ b/src/corelib/Providers/Rackspace/ComputeProvider.cs
@@ -638,9 +638,9 @@ namespace net.openstack.Providers.Rackspace
         private IComputeProvider BuildProvider(CloudIdentity identity)
         {
             if (identity == null)
-                identity = _defaultIdentity;
+                identity = DefaultIdentity;
 
-            return new ComputeProvider(identity, _identityProvider, _restService);
+            return new ComputeProvider(identity, IdentityProvider, RestService);
         }
 
         #endregion

--- a/src/corelib/Providers/Rackspace/ObjectStoreProvider.cs
+++ b/src/corelib/Providers/Rackspace/ObjectStoreProvider.cs
@@ -433,25 +433,15 @@ namespace net.openstack.Providers.Rackspace
             return processedHeaders[ObjectStoreConstants.ProcessedHeadersHeaderKey];
         }
 
-        public void CreateObjectFromFile(CloudIdentity identity, string container, string filePath, string objectName, int chunkSize = 65536, string region = null, Action<long> progressUpdated = null)
+        public void CreateObjectFromFile(string container, string filePath, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null, CloudIdentity identity = null)
         {
-            Stream stream = System.IO.File.OpenRead(filePath);
-            CreateObjectFromStream(identity, container, stream, objectName, chunkSize, null, region, progressUpdated);
+            using (var stream = System.IO.File.OpenRead(filePath))
+            {
+                CreateObjectFromStream(container, stream, objectName, chunkSize, headers, region, progressUpdated, identity);
+            }
         }
 
-        public void CreateObjectFromFile(CloudIdentity identity, string container, string filePath, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null)
-        {
-            Stream stream = System.IO.File.OpenRead(filePath);
-
-            CreateObjectFromStream(identity, container, stream, objectName, chunkSize, headers, region, progressUpdated);
-        }
-
-        public void CreateObjectFromStream(CloudIdentity identity, string container, Stream stream, string objectName, int chunkSize = 65536, string region = null, Action<long> progressUpdated = null)
-        {
-            CreateObjectFromStream(identity, container, stream, objectName, chunkSize, null, region, progressUpdated);
-        }
-
-        public void CreateObjectFromStream(CloudIdentity identity, string container, Stream stream, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null)
+        public void CreateObjectFromStream(string container, Stream stream, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null, CloudIdentity identity = null)
         {
             if (stream == null)
                 throw new ArgumentNullException();

--- a/src/corelib/Providers/Rackspace/ProviderBase.cs
+++ b/src/corelib/Providers/Rackspace/ProviderBase.cs
@@ -17,34 +17,34 @@ namespace net.openstack.Providers.Rackspace
 {
     public class ProviderBase
     {
-        protected readonly IIdentityProvider _identityProvider;
-        protected readonly IRestService _restService;
-        protected readonly CloudIdentity _defaultIdentity;
+        protected readonly IIdentityProvider IdentityProvider;
+        protected readonly IRestService RestService;
+        protected readonly CloudIdentity DefaultIdentity;
 
         protected ProviderBase(CloudIdentity defaultIdentity, IIdentityProvider identityProvider, IRestService restService)
         {
-            _defaultIdentity = defaultIdentity;
-            _identityProvider = identityProvider;
-            _restService = restService;
+            DefaultIdentity = defaultIdentity;
+            IdentityProvider = identityProvider;
+            RestService = restService;
         }
         
         protected Response<T> ExecuteRESTRequest<T>(CloudIdentity identity, Uri absoluteUri, HttpMethod method, object body = null, Dictionary<string, string> queryStringParameter = null, Dictionary<string, string> headers = null,  bool isRetry = false, JsonRequestSettings settings = null)
         {
             return ExecuteRESTRequest<Response<T>>(identity, absoluteUri, method, body, queryStringParameter, headers, isRetry, settings,
-                                                   (uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings) => _restService.Execute<T>(uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings));
+                                                   (uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings) => RestService.Execute<T>(uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings));
         }
 
         protected Response ExecuteRESTRequest(CloudIdentity identity, Uri absoluteUri, HttpMethod method, object body = null, Dictionary<string, string> queryStringParameter = null, Dictionary<string, string> headers = null, bool isRetry = false, JsonRequestSettings settings = null)
         {
             return ExecuteRESTRequest<Response>(identity, absoluteUri, method, body, queryStringParameter, headers, isRetry, settings,
-                                       (uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings) => _restService.Execute(uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings));
+                                       (uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings) => RestService.Execute(uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings));
 
         }
 
         protected Response ExecuteRESTRequest(CloudIdentity identity, Uri absoluteUri, HttpMethod method, Func<HttpWebResponse, bool, Response> buildResponseCallback, object body = null, Dictionary<string, string> queryStringParameter = null, Dictionary<string, string> headers = null, bool isRetry = false, JsonRequestSettings settings = null)
         {
             return ExecuteRESTRequest<Response>(identity, absoluteUri, method, body, queryStringParameter, headers, isRetry, settings,
-                                       (uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings) => _restService.Execute(uri, requestMethod, buildResponseCallback, requestBody, requestHeaders, requestQueryParams, requestSettings));
+                                       (uri, requestMethod, requestBody, requestHeaders, requestQueryParams, requestSettings) => RestService.Execute(uri, requestMethod, buildResponseCallback, requestBody, requestHeaders, requestQueryParams, requestSettings));
 
         }
 
@@ -52,7 +52,7 @@ namespace net.openstack.Providers.Rackspace
             Func<Uri, HttpMethod, string, Dictionary<string, string>, Dictionary<string, string>, JsonRequestSettings, T> callback) where T : Response
         {
             if (identity == null)
-                identity = _defaultIdentity;
+                identity = DefaultIdentity;
 
             if (requestSettings == null)
                 requestSettings = BuildDefaultRequestSettings();
@@ -60,7 +60,7 @@ namespace net.openstack.Providers.Rackspace
             if (headers == null)
                 headers = new Dictionary<string, string>();
 
-            headers.Add("X-Auth-Token", _identityProvider.GetToken(identity, isRetry));
+            headers.Add("X-Auth-Token", IdentityProvider.GetToken(identity, isRetry));
 
             string bodyStr = null;
             if (body != null)
@@ -99,12 +99,12 @@ namespace net.openstack.Providers.Rackspace
             if (headers == null)
                 headers = new Dictionary<string, string>();
 
-            headers.Add("X-Auth-Token", _identityProvider.GetToken(identity, isRetry));
+            headers.Add("X-Auth-Token", IdentityProvider.GetToken(identity, isRetry));
 
             if (string.IsNullOrWhiteSpace(requestSettings.UserAgent))
                 requestSettings.UserAgent = GetUserAgentHeaderValue();
 
-            var response = _restService.Stream(absoluteUri, method, stream, chunkSize, headers, queryStringParameter, requestSettings, progressUpdated);
+            var response = RestService.Stream(absoluteUri, method, stream, chunkSize, headers, queryStringParameter, requestSettings, progressUpdated);
 
             // on errors try again 1 time.
             if (response.StatusCode == 401)
@@ -132,9 +132,9 @@ namespace net.openstack.Providers.Rackspace
         private Endpoint GetServiceEndpoint(CloudIdentity identity, string serviceName, string region = null)
         {
             if (identity == null)
-                identity = _defaultIdentity;
+                identity = DefaultIdentity;
 
-            var userAccess = _identityProvider.GetUserAccess(identity);
+            var userAccess = IdentityProvider.GetUserAccess(identity);
 
             if (userAccess == null || userAccess.ServiceCatalog == null)
                 throw new UserAuthenticationException("Unable to authenticate user and retrieve authorized service endpoints");

--- a/src/testing/integration/Providers/Rackspace/ObjectStoreTests.cs
+++ b/src/testing/integration/Providers/Rackspace/ObjectStoreTests.cs
@@ -476,8 +476,8 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             int cnt = 0;
             var info = new FileInfo(filePath);
             var totalBytest = info.Length;
-            var provider = new ObjectStoreProvider();
-            provider.CreateObjectFromStream(_testIdentity, containerName, stream, fileName, 65536, headers, null, (bytesWritten) =>
+            var provider = new ObjectStoreProvider(_testIdentity);
+            provider.CreateObjectFromStream(containerName, stream, fileName, 65536, headers, null, (bytesWritten) =>
             {
                 cnt = cnt + 1;
                 if (cnt % 10 != 0)
@@ -520,8 +520,8 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             var etag = GetMD5Hash(filePath);
             stream.Position = 0;
             var headers = new Dictionary<string, string>();
-            var provider = new ObjectStoreProvider();
-            provider.CreateObjectFromStream(_testIdentity, containerName, stream, fileName, 65536, headers);
+            var provider = new ObjectStoreProvider(_testIdentity);
+            provider.CreateObjectFromStream(containerName, stream, fileName, 65536, headers);
 
             var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
             Assert.AreEqual(fileName, containerGetObjectsResponse.Where(x => x.Name.Equals(fileName, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Name);
@@ -542,8 +542,8 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             int cnt = 0;
             var info = new FileInfo(filePath);
             var totalBytest = info.Length;
-            var provider = new ObjectStoreProvider();
-            provider.CreateObjectFromFile(_testIdentity, containerName, filePath, fileName, 65536, headers, null, (bytesWritten) =>
+            var provider = new ObjectStoreProvider(_testIdentity);
+            provider.CreateObjectFromFile(containerName, filePath, fileName, 65536, headers, null, (bytesWritten) =>
             {
                 cnt = cnt + 1;
                 if (cnt % 10 != 0)
@@ -571,8 +571,8 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const string filePath = @"C:\Users\Public\Pictures\Sample Pictures\Desert.jpg";
             string fileName = Path.GetFileName(filePath);
             var headers = new Dictionary<string, string>();
-            var provider = new ObjectStoreProvider();
-            provider.CreateObjectFromFile(_testIdentity, containerName, filePath, fileName, 65536, headers);
+            var provider = new ObjectStoreProvider(_testIdentity);
+            provider.CreateObjectFromFile(containerName, filePath, fileName, 65536, headers);
 
             var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
             Assert.AreEqual(fileName, containerGetObjectsResponse.Where(x => x.Name.Equals(fileName, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Name);


### PR DESCRIPTION
### Changes
- Update the **ObjectStoreProvider.CreateObjectFromFile** to open stream and wrap usage in a using statement to ensure disposing of the stream
- Fixed the naming convention of the **ProviderBase** protected properties
- Modified the **ObjectStoreProvider.CreateObjectFromFile** and **ObjectStoreProvider.CreateObjectFromStream** methods to move the identity object to the last parameter and make it optional.
  - Updated to tests to match
