### PR TITLE
[Delivers #43555165 #47573637]Purge CDN Object functionality.Move CloudIdentity parameter to the end of all IObjectStoreProvider methods and make it nullable

### DIFF
--- a/src/corelib/Core/Domain/ObjectStore.cs
+++ b/src/corelib/Core/Domain/ObjectStore.cs
@@ -14,6 +14,7 @@ namespace net.openstack.Core.Domain
         ContainerNotEmpty,
         ContainerNotFound,
         ObjectDeleted,
-        ObjectCreated
+        ObjectCreated,
+        ObjectPurged
     }
 }

--- a/src/corelib/Core/IObjectStoreProvider.cs
+++ b/src/corelib/Core/IObjectStoreProvider.cs
@@ -12,25 +12,25 @@ namespace net.openstack.Core
     {
         #region Container
 
-        IEnumerable<Container> ListContainers(CloudIdentity identity, int? limit = null, string markerId = null, string markerEnd = null, string format = "json", string region = null);
-        ObjectStore CreateContainer(CloudIdentity identity, string container, string region = null);
-        ObjectStore DeleteContainer(CloudIdentity identity, string container, string region = null);
-        Dictionary<string, string> GetContainerHeader(CloudIdentity identity, string container, string region = null, bool useInternalUrl = false);
-        Dictionary<string, string> GetContainerMetaData(CloudIdentity identity, string container, string region = null, bool useInternalUrl = false);
-        Dictionary<string, string> GetContainerCDNHeader(CloudIdentity identity, string container, string region = null, bool useInternalUrl = false);
+        IEnumerable<Container> ListContainers(int? limit = null, string markerId = null, string markerEnd = null, string format = "json", string region = null, CloudIdentity identity = null);
+        ObjectStore CreateContainer(string container, string region = null, CloudIdentity identity = null);
+        ObjectStore DeleteContainer(string container, string region = null, CloudIdentity identity = null);
+        Dictionary<string, string> GetContainerHeader(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
+        Dictionary<string, string> GetContainerMetaData(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
+        Dictionary<string, string> GetContainerCDNHeader(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
 
-        IEnumerable<ContainerCDN> ListCDNContainers(CloudIdentity identity, int? limit = null, string markerId = null, string markerEnd = null, bool cdnEnabled = false, string region = null);
+        IEnumerable<ContainerCDN> ListCDNContainers(int? limit = null, string markerId = null, string markerEnd = null, bool cdnEnabled = false, string region = null, CloudIdentity identity = null);
 
-        Dictionary<string, string> EnableCDNOnContainer(CloudIdentity identity, string container, long ttl, string region = null);
-        Dictionary<string, string> EnableCDNOnContainer(CloudIdentity identity, string container, bool logRetention, string region = null);
-        Dictionary<string, string> EnableCDNOnContainer(CloudIdentity identity, string container, long ttl, bool logRetention, string region = null);
+        Dictionary<string, string> EnableCDNOnContainer(string container, long ttl, string region = null, CloudIdentity identity = null);
+        Dictionary<string, string> EnableCDNOnContainer(string container, bool logRetention, string region = null, CloudIdentity identity = null);
+        Dictionary<string, string> EnableCDNOnContainer(string container, long ttl, bool logRetention, string region = null, CloudIdentity identity = null);
 
-        Dictionary<string, string> DisableCDNOnContainer(CloudIdentity identity, string container, string region = null);
+        Dictionary<string, string> DisableCDNOnContainer(string container, string region = null, CloudIdentity identity = null);
 
 
-        void AddContainerMetadata(CloudIdentity identity, string container, Dictionary<string, string> metadata, string region = null, bool useInternalUrl = false);
-        void AddContainerHeaders(CloudIdentity identity, string container, Dictionary<string, string> headers, string region = null, bool useInternalUrl = false);
-        void AddContainerCdnHeaders(CloudIdentity identity, string container, Dictionary<string, string> headers, string region = null, bool useInternalUrl = false);
+        void AddContainerMetadata(string container, Dictionary<string, string> metadata, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
+        void AddContainerHeaders(string container, Dictionary<string, string> headers, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
+        void AddContainerCdnHeaders(string container, Dictionary<string, string> headers, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
 
         void EnableStaticWebOnContainer(string container, string index, string error, string css, bool listing, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
         void EnableStaticWebOnContainer(string container, string index, string error, bool listing, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
@@ -41,16 +41,20 @@ namespace net.openstack.Core
 
         #region Container Objects
 
-        IEnumerable<ContainerObject> GetObjects(CloudIdentity identity, string container, int? limit = null, string markerId = null, string markerEnd = null, string format = "json", string region = null);
+        IEnumerable<ContainerObject> GetObjects(string container, int? limit = null, string markerId = null, string markerEnd = null, string format = "json", string region = null, CloudIdentity identity = null);
         void CreateObjectFromFile(string container, string filePath, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null, CloudIdentity identity = null);
         void CreateObjectFromStream(string container, Stream stream, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null, CloudIdentity identity = null);
         void GetObjectSaveToFile(string container, string saveDirectory, string objectName, string fileName = null, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, bool verifyEtag = false, CloudIdentity identity = null);
         void GetObject(string container, string objectName, Stream outputStream, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, bool verifyEtag = false, CloudIdentity identity = null);
-        ObjectStore DeleteObject(CloudIdentity identity, string container, string objectNmae, Dictionary<string, string> headers = null, string region = null);
-        ObjectStore CopyObject(CloudIdentity identity, string sourceContainer, string sourceObjectName, string destinationContainer, string destinationObjectName, Dictionary<string, string> headers = null, string region = null);
+        ObjectStore DeleteObject(string container, string objectNmae, Dictionary<string, string> headers = null, string region = null, CloudIdentity identity = null);
+        ObjectStore CopyObject(string sourceContainer, string sourceObjectName, string destinationContainer, string destinationObjectName, Dictionary<string, string> headers = null, string region = null, CloudIdentity identity = null);
 
-        Dictionary<string, string> GetObjectHeaders(CloudIdentity identity, string container, string objectName, string format = "json", string region = null);
+        Dictionary<string, string> GetObjectHeaders(string container, string objectName, string format = "json", string region = null, CloudIdentity identity = null);
         Dictionary<string, string> GetObjectMetaData(string container, string objectName, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
+
+        ObjectStore PurgeObjectFromCDN(string container, string objectName, string region = null, CloudIdentity identity = null);
+        ObjectStore PurgeObjectFromCDN(string container, string objectName, string email, string region = null, CloudIdentity identity = null);
+        ObjectStore PurgeObjectFromCDN(string container, string objectName, string[] emails, string region = null, CloudIdentity identity = null);
         #endregion
 
         //string Name { get; }

--- a/src/corelib/Providers/Rackspace/ObjectStoreProvider.cs
+++ b/src/corelib/Providers/Rackspace/ObjectStoreProvider.cs
@@ -39,7 +39,7 @@ namespace net.openstack.Providers.Rackspace
 
         #region Containers
 
-        public IEnumerable<Container> ListContainers(CloudIdentity identity, int? limit = null, string marker = null, string markerEnd = null, string format = "json", string region = null)
+        public IEnumerable<Container> ListContainers(int? limit = null, string marker = null, string markerEnd = null, string format = "json", string region = null, CloudIdentity identity = null)
         {
             var urlPath = new Uri(string.Format("{0}", GetServiceEndpointCloudFiles(identity, region)));
 
@@ -64,7 +64,7 @@ namespace net.openstack.Providers.Rackspace
 
         }
 
-        public ObjectStore CreateContainer(CloudIdentity identity, string container, string region = null)
+        public ObjectStore CreateContainer(string container, string region = null, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region), container));
@@ -79,7 +79,7 @@ namespace net.openstack.Providers.Rackspace
             return ObjectStore.Unknown;
         }
 
-        public ObjectStore DeleteContainer(CloudIdentity identity, string container, string region = null)
+        public ObjectStore DeleteContainer(string container, string region = null, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region), container));
@@ -96,7 +96,7 @@ namespace net.openstack.Providers.Rackspace
             return ObjectStore.Unknown;
         }
 
-        public Dictionary<string, string> GetContainerHeader(CloudIdentity identity, string container, string region = null, bool useInternalUrl = false)
+        public Dictionary<string, string> GetContainerHeader(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region), container));
@@ -108,7 +108,7 @@ namespace net.openstack.Providers.Rackspace
             return processedHeaders[ObjectStoreConstants.ProcessedHeadersHeaderKey];
         }
 
-        public Dictionary<string, string> GetContainerMetaData(CloudIdentity identity, string container, string region = null, bool useInternalUrl = false)
+        public Dictionary<string, string> GetContainerMetaData(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region), container));
@@ -120,7 +120,7 @@ namespace net.openstack.Providers.Rackspace
             return processedHeaders[ObjectStoreConstants.ProcessedHeadersMetadataKey];
         }
 
-        public Dictionary<string, string> GetContainerCDNHeader(CloudIdentity identity, string container, string region = null, bool useInternalUrl = false)
+        public Dictionary<string, string> GetContainerCDNHeader(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
 
@@ -131,7 +131,7 @@ namespace net.openstack.Providers.Rackspace
             return response.Headers.ToDictionary(header => header.Key, header => header.Value);
         }
 
-        public void AddContainerMetadata(CloudIdentity identity, string container, Dictionary<string, string> metadata, string region = null, bool useInternalUrl = false)
+        public void AddContainerMetadata(string container, Dictionary<string, string> metadata, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             if (metadata.Equals(null))
@@ -157,7 +157,7 @@ namespace net.openstack.Providers.Rackspace
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.POST, headers: headers);
         }
 
-        public void AddContainerHeaders(CloudIdentity identity, string container, Dictionary<string, string> headers, string region = null, bool useInternalUrl = false)
+        public void AddContainerHeaders(string container, Dictionary<string, string> headers, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             if (headers == null)
@@ -170,7 +170,7 @@ namespace net.openstack.Providers.Rackspace
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.POST, headers: headers);
         }
 
-        public void AddContainerCdnHeaders(CloudIdentity identity, string container, Dictionary<string, string> headers, string region = null, bool useInternalUrl = false)
+        public void AddContainerCdnHeaders(string container, Dictionary<string, string> headers, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             if (headers == null)
@@ -178,7 +178,7 @@ namespace net.openstack.Providers.Rackspace
                 throw new ArgumentNullException();
             }
 
-            if (!IsContainerCdnEnabled(identity, container, region, useInternalUrl))
+            if (!IsContainerCdnEnabled(container, region, useInternalUrl, identity))
             {
                 throw new CDNNotEnabledException();
             }
@@ -189,11 +189,11 @@ namespace net.openstack.Providers.Rackspace
             }
         }
 
-        private bool IsContainerCdnEnabled(CloudIdentity identity, string container, string region, bool useInternalUrl)
+        private bool IsContainerCdnEnabled(string container, string region, bool useInternalUrl, CloudIdentity identity = null)
         {
             bool cdnEnabled = false;
 
-            var cdnHeaders = GetContainerCDNHeader(identity, container, region, useInternalUrl);
+            var cdnHeaders = GetContainerCDNHeader(container, region, useInternalUrl, identity: identity);
             if (cdnHeaders.ContainsKey(ObjectStoreConstants.CdnEnabled))
             {
                 cdnEnabled =
@@ -205,7 +205,7 @@ namespace net.openstack.Providers.Rackspace
             return cdnEnabled;
         }
 
-        public IEnumerable<ContainerCDN> ListCDNContainers(CloudIdentity identity, int? limit = null, string marker = null, string markerEnd = null, bool cdnEnabled = false, string region = null)
+        public IEnumerable<ContainerCDN> ListCDNContainers(int? limit = null, string marker = null, string markerEnd = null, bool cdnEnabled = false, string region = null, CloudIdentity identity = null)
         {
             var urlPath = new Uri(string.Format("{0}", GetServiceEndpointCloudFilesCDN(identity, region)));
 
@@ -230,17 +230,17 @@ namespace net.openstack.Providers.Rackspace
             return response.Data;
         }
 
-        public Dictionary<string, string> EnableCDNOnContainer(CloudIdentity identity, string container, long ttl, string region = null)
+        public Dictionary<string, string> EnableCDNOnContainer(string container, long ttl, string region = null, CloudIdentity identity = null)
         {
-            return EnableCDNOnContainer(identity, container, ttl, false);
+            return EnableCDNOnContainer(container, ttl, false, identity: identity);
         }
 
-        public Dictionary<string, string> EnableCDNOnContainer(CloudIdentity identity, string container, bool logRetention, string region = null)
+        public Dictionary<string, string> EnableCDNOnContainer(string container, bool logRetention, string region = null, CloudIdentity identity = null)
         {
-            return EnableCDNOnContainer(identity, container, 259200, logRetention, region);
+            return EnableCDNOnContainer(container, 259200, logRetention, region,identity);
         }
 
-        public Dictionary<string, string> EnableCDNOnContainer(CloudIdentity identity, string container, long ttl, bool logRetention, string region = null)
+        public Dictionary<string, string> EnableCDNOnContainer(string container, long ttl, bool logRetention, string region = null, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             if (ttl.Equals(null) || logRetention.Equals(null))
@@ -269,7 +269,7 @@ namespace net.openstack.Providers.Rackspace
             return response.Headers.ToDictionary(header => header.Key, header => header.Value);
         }
 
-        public Dictionary<string, string> DisableCDNOnContainer(CloudIdentity identity, string container, string region = null)
+        public Dictionary<string, string> DisableCDNOnContainer(string container, string region = null, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
 
@@ -292,7 +292,7 @@ namespace net.openstack.Providers.Rackspace
         {
             _objectStoreHelper.ValidateContainerName(container);
 
-            if (!IsContainerCdnEnabled(identity, container, region, useInternalUrl))
+            if (!IsContainerCdnEnabled(container, region, useInternalUrl, identity))
             {
                 throw new CDNNotEnabledException();
             }
@@ -305,7 +305,7 @@ namespace net.openstack.Providers.Rackspace
                                       {ObjectStoreConstants.WebListingsCSS, css},
                                       {ObjectStoreConstants.WebListings, listing.ToString()}
                                   };
-                AddContainerHeaders(identity, container, headers, region, useInternalUrl);
+                AddContainerHeaders(container, headers, region, useInternalUrl, identity);
             }
         }
 
@@ -313,7 +313,7 @@ namespace net.openstack.Providers.Rackspace
         {
             _objectStoreHelper.ValidateContainerName(container);
 
-            if (!IsContainerCdnEnabled(identity, container, region, useInternalUrl))
+            if (!IsContainerCdnEnabled(container, region, useInternalUrl, identity))
             {
                 throw new CDNNotEnabledException();
             }
@@ -325,7 +325,7 @@ namespace net.openstack.Providers.Rackspace
                                       {ObjectStoreConstants.WebError, error},
                                       {ObjectStoreConstants.WebListings, listing.ToString()}
                                   };
-                AddContainerHeaders(identity, container, headers, region, useInternalUrl);
+                AddContainerHeaders(container, headers, region, useInternalUrl, identity);
             }
         }
 
@@ -333,7 +333,7 @@ namespace net.openstack.Providers.Rackspace
         {
             _objectStoreHelper.ValidateContainerName(container);
 
-            if (!IsContainerCdnEnabled(identity, container, region, useInternalUrl))
+            if (!IsContainerCdnEnabled(container, region, useInternalUrl, identity))
             {
                 throw new CDNNotEnabledException();
             }
@@ -344,7 +344,7 @@ namespace net.openstack.Providers.Rackspace
                                       {ObjectStoreConstants.WebListingsCSS, css},
                                       {ObjectStoreConstants.WebListings, listing.ToString()}
                                   };
-                AddContainerHeaders(identity, container, headers, region, useInternalUrl);
+                AddContainerHeaders(container, headers, region, useInternalUrl, identity);
             }
         }
 
@@ -352,7 +352,7 @@ namespace net.openstack.Providers.Rackspace
         {
             _objectStoreHelper.ValidateContainerName(container);
 
-            if (!IsContainerCdnEnabled(identity, container, region, useInternalUrl))
+            if (!IsContainerCdnEnabled(container, region, useInternalUrl, identity))
             {
                 throw new CDNNotEnabledException();
             }
@@ -363,7 +363,7 @@ namespace net.openstack.Providers.Rackspace
                                       {ObjectStoreConstants.WebIndex, index},
                                       {ObjectStoreConstants.WebError, error}
                                   };
-                AddContainerHeaders(identity, container, headers, region, useInternalUrl);
+                AddContainerHeaders(container, headers, region, useInternalUrl, identity);
             }
         }
 
@@ -371,7 +371,7 @@ namespace net.openstack.Providers.Rackspace
         {
             _objectStoreHelper.ValidateContainerName(container);
 
-            if (!IsContainerCdnEnabled(identity, container, region, useInternalUrl))
+            if (!IsContainerCdnEnabled(container, region, useInternalUrl, identity))
             {
                 throw new CDNNotEnabledException();
             }
@@ -384,7 +384,7 @@ namespace net.openstack.Providers.Rackspace
                                       {ObjectStoreConstants.WebListingsCSS, string.Empty},
                                       {ObjectStoreConstants.WebListings, string.Empty}
                                   };
-                AddContainerHeaders(identity, container, headers, region, useInternalUrl);
+                AddContainerHeaders( container, headers, region, useInternalUrl, identity);
             }
         }
 
@@ -392,7 +392,7 @@ namespace net.openstack.Providers.Rackspace
 
         #region Container Objects
 
-        public IEnumerable<ContainerObject> GetObjects(CloudIdentity identity, string container, int? limit = null, string marker = null, string markerEnd = null, string format = "json", string region = null)
+        public IEnumerable<ContainerObject> GetObjects(string container, int? limit = null, string marker = null, string markerEnd = null, string format = "json", string region = null, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region), container));
@@ -420,7 +420,7 @@ namespace net.openstack.Providers.Rackspace
             return response.Data;
         }
 
-        public Dictionary<string, string> GetObjectHeaders(CloudIdentity identity, string container, string objectName, string format = "json", string region = null)
+        public Dictionary<string, string> GetObjectHeaders(string container, string objectName, string format = "json", string region = null, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             _objectStoreHelper.ValidateObjectName(objectName);
@@ -528,7 +528,7 @@ namespace net.openstack.Providers.Rackspace
             }
         }
 
-        public ObjectStore DeleteObject(CloudIdentity identity, string container, string objectName, Dictionary<string, string> headers = null, string region = null)
+        public ObjectStore DeleteObject(string container, string objectName, Dictionary<string, string> headers = null, string region = null, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(container);
             _objectStoreHelper.ValidateObjectName(objectName);
@@ -546,7 +546,7 @@ namespace net.openstack.Providers.Rackspace
 
         }
 
-        public ObjectStore CopyObject(CloudIdentity identity, string sourceContainer, string sourceObjectName, string destinationContainer, string destinationObjectName, Dictionary<string, string> headers = null, string region = null)
+        public ObjectStore CopyObject(string sourceContainer, string sourceObjectName, string destinationContainer, string destinationObjectName, Dictionary<string, string> headers = null, string region = null, CloudIdentity identity = null)
         {
             _objectStoreHelper.ValidateContainerName(sourceContainer);
             _objectStoreHelper.ValidateObjectName(sourceObjectName);
@@ -597,24 +597,69 @@ namespace net.openstack.Providers.Rackspace
             return processedHeaders[ObjectStoreConstants.ProcessedHeadersMetadataKey];
         }
 
+        public ObjectStore PurgeObjectFromCDN(string container, string objectName, string region = null, CloudIdentity identity = null)
+        {
+            return PurgeObjectFromCDN(container, objectName, " ", region, identity);
+        }
+
+        public ObjectStore PurgeObjectFromCDN(string container, string objectName, string[] emails, string region = null, CloudIdentity identity = null)
+        {
+            if (emails.Length < 0)
+            {
+                throw new ArgumentNullException();
+            }
+
+            return PurgeObjectFromCDN(container, objectName, string.Join(",", emails), region, identity);
+        }
+
+        public ObjectStore PurgeObjectFromCDN(string container, string objectName, string email, string region = null, CloudIdentity identity = null)
+        {
+            _objectStoreHelper.ValidateContainerName(container);
+            _objectStoreHelper.ValidateObjectName(objectName);
+
+            if (string.IsNullOrEmpty(email))
+            {
+                throw new ArgumentNullException();
+            }
+
+            if (!IsContainerCdnEnabled(container, region, true, identity))
+            {
+                throw new CDNNotEnabledException();
+            }
+            else
+            {
+                var headers = new Dictionary<string, string>();
+                if (email.Trim().Length > 0)
+                {
+                    headers[ObjectStoreConstants.CdnPurgeEmail] = email;
+                }
+                var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFilesCDN(identity, region), container, objectName));
+                var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.DELETE, headers: headers);
+                if (response.StatusCode == 204)
+                    return ObjectStore.ObjectPurged;
+
+                return ObjectStore.Unknown;
+            }
+
+        }
 
         #endregion
 
         #region Private methods
 
-        private string GetObjectContentLength(CloudIdentity identity, string sourceContainer, string sourceObjectName, string region)
+        private string GetObjectContentLength(CloudIdentity identity,string sourceContainer, string sourceObjectName, string region)
         {
-            var sourceHeaders = GetObjectHeaders(identity, sourceContainer, sourceObjectName, null, region);
+            var sourceHeaders = GetObjectHeaders(sourceContainer, sourceObjectName, null, region, identity);
             var contentLength = sourceHeaders.FirstOrDefault(x => x.Key.Equals(ObjectStoreConstants.ContentLength, StringComparison.OrdinalIgnoreCase)).Value;
             return contentLength;
         }
 
-        protected string GetServiceEndpointCloudFiles(CloudIdentity identity, string region = null)
+        protected string GetServiceEndpointCloudFiles(CloudIdentity identity,string region = null)
         {
             return base.GetPublicServiceEndpoint(identity, "cloudFiles", region);
         }
 
-        protected string GetServiceEndpointCloudFilesCDN(CloudIdentity identity, string region = null)
+        protected string GetServiceEndpointCloudFilesCDN(CloudIdentity identity,string region = null)
         {
             return base.GetPublicServiceEndpoint(identity, "cloudFilesCDN", region);
         }

--- a/src/testing/integration/Providers/Rackspace/ObjectStoreTests.cs
+++ b/src/testing/integration/Providers/Rackspace/ObjectStoreTests.cs
@@ -57,7 +57,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Return_Container_List()
         {
             var provider = new ObjectStoreProvider();
-            var containerList = provider.ListContainers(_testIdentity);
+            var containerList = provider.ListContainers(identity:_testIdentity);
 
             Assert.IsNotNull(containerList);
             Assert.IsTrue(containerList.Any());
@@ -67,7 +67,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Return_Container_List_With_Limit()
         {
             var provider = new ObjectStoreProvider();
-            var containerList = provider.ListContainers(_testIdentity, 1);
+            var containerList = provider.ListContainers( 1,identity:_testIdentity);
 
             Assert.IsNotNull(containerList);
             Assert.AreEqual(1, containerList.Count());
@@ -77,7 +77,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Return_Container_List_With_Start_Marker_Lower_Case()
         {
             var provider = new ObjectStoreProvider();
-            var containerList = provider.ListContainers(_testIdentity, null, "a");
+            var containerList = provider.ListContainers(null, "a", identity: _testIdentity);
 
             Assert.IsNotNull(containerList);
             Assert.IsTrue(containerList.Any());
@@ -87,7 +87,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Return_Container_List_With_Start_Marker_Upper_Case()
         {
             var provider = new ObjectStoreProvider();
-            var containerList = provider.ListContainers(_testIdentity, null, "A");
+            var containerList = provider.ListContainers(null, "A", identity: _testIdentity);
 
             Assert.IsNotNull(containerList);
             Assert.IsTrue(containerList.Any());
@@ -98,7 +98,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Return_Container_List_With_End_Marker_Upper_Case()
         {
             var provider = new ObjectStoreProvider();
-            var containerList = provider.ListContainers(_testIdentity, null, null, "L");
+            var containerList = provider.ListContainers(null, null, "L", identity: _testIdentity);
 
             Assert.IsNotNull(containerList);
             Assert.IsTrue(containerList.Any());
@@ -108,7 +108,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Return_Container_List_With_End_Marker_Lower_Case()
         {
             var provider = new ObjectStoreProvider();
-            var containerList = provider.ListContainers(_testIdentity, null, null, "l");
+            var containerList = provider.ListContainers(null, null, "l", identity: _testIdentity);
 
             Assert.IsNotNull(containerList);
             Assert.IsTrue(containerList.Any());
@@ -119,7 +119,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "TestContainer";
             var provider = new ObjectStoreProvider();
-            var containerCreatedResponse = provider.CreateContainer(_testIdentity, containerName);
+            var containerCreatedResponse = provider.CreateContainer(containerName, identity: _testIdentity);
 
             Assert.AreEqual(ObjectStore.ContainerCreated, containerCreatedResponse);
         }
@@ -129,7 +129,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "TestContainer";
             var provider = new ObjectStoreProvider();
-            var containerCreatedResponse = provider.CreateContainer(_testIdentity, containerName);
+            var containerCreatedResponse = provider.CreateContainer(containerName, identity: _testIdentity);
 
             Assert.AreEqual(ObjectStore.ContainerExists, containerCreatedResponse);
         }
@@ -139,7 +139,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "TestContainer";
             var provider = new ObjectStoreProvider();
-            var containerCreatedResponse = provider.DeleteContainer(_testIdentity, containerName);
+            var containerCreatedResponse = provider.DeleteContainer(containerName, identity: _testIdentity);
 
             Assert.AreEqual(ObjectStore.ContainerDeleted, containerCreatedResponse);
         }
@@ -149,7 +149,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "DarkKnight";
             var provider = new ObjectStoreProvider();
-            var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
+            var containerGetObjectsResponse = provider.GetObjects(containerName, identity: _testIdentity);
 
             Assert.IsNotNull(containerGetObjectsResponse);
         }
@@ -160,7 +160,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "No_Container_Present";
             var provider = new ObjectStoreProvider();
-            var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
+            var containerGetObjectsResponse = provider.GetObjects(containerName, identity: _testIdentity);
             Assert.Fail("Expected exception was not thrown.");
         }
 
@@ -170,7 +170,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "RK_Teat";
             var provider = new ObjectStoreProvider();
-            var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
+            var containerGetObjectsResponse = provider.GetObjects(containerName, identity: _testIdentity);
             Assert.Fail("Expected exception was not thrown.");
         }
 
@@ -179,7 +179,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "DarkKnight";
             var provider = new ObjectStoreProvider();
-            var objectHeadersResponse = provider.GetContainerHeader(_testIdentity, containerName);
+            var objectHeadersResponse = provider.GetContainerHeader(containerName, identity: _testIdentity);
 
             Assert.IsNotNull(objectHeadersResponse);
             //Assert.AreEqual("Christian Bale", objectHeadersResponse.Where(x => x.Key.Equals("X-Object-Meta-Actor", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
@@ -190,7 +190,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "DarkKnight";
             var provider = new ObjectStoreProvider();
-            var objectHeadersResponse = provider.GetContainerMetaData(_testIdentity, containerName);
+            var objectHeadersResponse = provider.GetContainerMetaData(containerName, identity: _testIdentity);
 
             Assert.IsNotNull(objectHeadersResponse);
             Assert.IsFalse(bool.Parse(objectHeadersResponse.Where(x => x.Key.Equals("Access-Log-Delivery", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
@@ -203,7 +203,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             var metaData = new Dictionary<string, string>();
             metaData.Add("X-Container-Meta-XXXX", "Test");
             var provider = new ObjectStoreProvider();
-            provider.AddContainerMetadata(_testIdentity, containerName, metaData);
+            provider.AddContainerMetadata(containerName, metaData, identity: _testIdentity);
         }
 
         [TestMethod]
@@ -214,7 +214,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             metaData.Add("X-Container-Meta-Movie", "Batman");
             metaData.Add("X-Container-Meta-Genre", "Action");
             var provider = new ObjectStoreProvider();
-            provider.AddContainerHeaders(_testIdentity, containerName, metaData);
+            provider.AddContainerHeaders(containerName, metaData, identity: _testIdentity);
         }
 
         [TestMethod]
@@ -222,7 +222,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "DarkKnight";
             var provider = new ObjectStoreProvider();
-            var objectHeadersResponse = provider.GetContainerCDNHeader(_testIdentity, containerName);
+            var objectHeadersResponse = provider.GetContainerCDNHeader(containerName, identity: _testIdentity);
 
             Assert.IsNotNull(objectHeadersResponse);
         }
@@ -233,7 +233,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "cloudservers";
             var provider = new ObjectStoreProvider();
-            var objectHeadersResponse = provider.GetContainerCDNHeader(_testIdentity, containerName);
+            var objectHeadersResponse = provider.GetContainerCDNHeader(containerName, identity: _testIdentity);
 
             Assert.Fail("Expected exception was not thrown.");
         }
@@ -246,7 +246,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             var provider = new ObjectStoreProvider();
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add("X-Log-Retention", "false");
-            provider.AddContainerCdnHeaders(_testIdentity, containerName, headers);
+            provider.AddContainerCdnHeaders(containerName, headers, identity: _testIdentity);
         }
 
         [TestMethod]
@@ -257,7 +257,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             var provider = new ObjectStoreProvider();
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add("X-Log-Retention", "false");
-            provider.AddContainerCdnHeaders(_testIdentity, containerName, headers);
+            provider.AddContainerCdnHeaders(containerName, headers, identity: _testIdentity);
             Assert.Fail("Expected exception was not thrown.");
         }
 
@@ -265,7 +265,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Get_CDN_Enabled_Containers()
         {
             var provider = new ObjectStoreProvider();
-            var cdnContainerList = provider.ListCDNContainers(_testIdentity, null, null, null, true);
+            var cdnContainerList = provider.ListCDNContainers(null, null, null, true, identity: _testIdentity);
 
             Assert.IsNotNull(cdnContainerList);
             Assert.IsTrue(cdnContainerList.All(x => x.CDNEnabled == true));
@@ -275,7 +275,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Get_CDN_All_Containers()
         {
             var provider = new ObjectStoreProvider();
-            var cdnContainerList = provider.ListCDNContainers(_testIdentity);
+            var cdnContainerList = provider.ListCDNContainers(identity: _testIdentity);
 
             Assert.IsNotNull(cdnContainerList);
             Assert.IsTrue(cdnContainerList.Any(x => x.CDNEnabled == true));
@@ -287,9 +287,9 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "DarkKnight";
             var provider = new ObjectStoreProvider();
-            var cdnEnabledResponse = provider.EnableCDNOnContainer(_testIdentity, containerName, 1000);
+            var cdnEnabledResponse = provider.EnableCDNOnContainer(containerName, 1000, identity: _testIdentity);
 
-            var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(_testIdentity, containerName);
+            var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(containerName, identity: _testIdentity);
 
             Assert.AreEqual(1000, int.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Ttl", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
             Assert.IsTrue(bool.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Cdn-Enabled", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
@@ -301,9 +301,9 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "DarkKnight";
             var provider = new ObjectStoreProvider();
-            var cdnEnabledResponse = provider.EnableCDNOnContainer(_testIdentity, containerName, true);
+            var cdnEnabledResponse = provider.EnableCDNOnContainer(containerName, true, identity: _testIdentity);
 
-            var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(_testIdentity, containerName);
+            var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(containerName, identity: _testIdentity);
 
             Assert.AreEqual(259200, int.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Ttl", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
             Assert.IsTrue(bool.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Log-Retention", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
@@ -316,9 +316,9 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             const string containerName = "DarkKnight";
             var provider = new ObjectStoreProvider();
-            var cdnEnabledResponse = provider.DisableCDNOnContainer(_testIdentity, containerName);
+            var cdnEnabledResponse = provider.DisableCDNOnContainer(containerName, identity: _testIdentity);
 
-            var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(_testIdentity, containerName);
+            var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(containerName, identity: _testIdentity);
 
             Assert.IsFalse(bool.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Cdn-Enabled", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
         }
@@ -333,10 +333,10 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const bool webListing = true;
 
             var provider = new ObjectStoreProvider();
-            //var cdnEnabledResponse = provider.EnableCDNOnContainer(_testIdentity, containerName, true);
+            //var cdnEnabledResponse = provider.EnableCDNOnContainer( containerName, true);
 
             provider.EnableStaticWebOnContainer(containerName, webIndex, webError, webListingsCSS, webListing, null, false, _testIdentity);
-            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(_testIdentity, containerName);
+            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(containerName, identity: _testIdentity);
 
             Assert.AreEqual(webIndex, cdnContainerMetaDataResponse.Where(x => x.Key.Equals("Web-index", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
             Assert.AreEqual(webError, cdnContainerMetaDataResponse.Where(x => x.Key.Equals("web-error", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
@@ -353,10 +353,10 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const bool webListing = true;
 
             var provider = new ObjectStoreProvider();
-            //var cdnEnabledResponse = provider.EnableCDNOnContainer(_testIdentity, containerName, true);
+            //var cdnEnabledResponse = provider.EnableCDNOnContainer( containerName, true, identity: _testIdentity);
 
             provider.EnableStaticWebOnContainer(containerName, webListingsCSS, webListing, null, false, _testIdentity);
-            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(_testIdentity, containerName);
+            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(containerName, identity: _testIdentity);
 
             Assert.AreEqual(webListingsCSS, cdnContainerMetaDataResponse.Where(x => x.Key.Equals("web-listings-css", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
             Assert.IsTrue(bool.Parse(cdnContainerMetaDataResponse.Where(x => x.Key.Equals("web-listings", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
@@ -372,10 +372,10 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const bool webListing = true;
 
             var provider = new ObjectStoreProvider();
-            //var cdnEnabledResponse = provider.EnableCDNOnContainer(_testIdentity, containerName, true);
+            //var cdnEnabledResponse = provider.EnableCDNOnContainer( containerName, true, identity: _testIdentity);
 
             provider.EnableStaticWebOnContainer(containerName, webIndex, webError, webListing, null, false, _testIdentity);
-            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(_testIdentity, containerName);
+            var cdnContainerMetaDataResponse = provider.GetContainerMetaData( containerName);
 
             Assert.AreEqual(webIndex, cdnContainerMetaDataResponse.Where(x => x.Key.Equals("Web-index", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
             Assert.AreEqual(webError, cdnContainerMetaDataResponse.Where(x => x.Key.Equals("web-error", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
@@ -391,10 +391,10 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const string webError = "error.html";
         
             var provider = new ObjectStoreProvider();
-            //var cdnEnabledResponse = provider.EnableCDNOnContainer(_testIdentity, containerName, true);
+            //var cdnEnabledResponse = provider.EnableCDNOnContainer( containerName, true, identity: _testIdentity);
 
             provider.EnableStaticWebOnContainer(containerName, webIndex, webError, null, false, _testIdentity);
-            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(_testIdentity, containerName);
+            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(containerName, identity: _testIdentity);
 
             Assert.AreEqual(webIndex, cdnContainerMetaDataResponse.Where(x => x.Key.Equals("Web-index", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
             Assert.AreEqual(webError, cdnContainerMetaDataResponse.Where(x => x.Key.Equals("web-error", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
@@ -406,10 +406,10 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const string containerName = "DarkKnight";
            
             var provider = new ObjectStoreProvider();
-            //var cdnEnabledResponse = provider.EnableCDNOnContainer(_testIdentity, containerName, true);
+            //var cdnEnabledResponse = provider.EnableCDNOnContainer( containerName, true, identity: _testIdentity);
 
             provider.DisableStaticWebOnContainer(containerName, null, false, _testIdentity);
-            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(_testIdentity, containerName);
+            var cdnContainerMetaDataResponse = provider.GetContainerMetaData(containerName, identity: _testIdentity);
 
             
             Assert.IsFalse(cdnContainerMetaDataResponse.ContainsKey("Web-Index"));
@@ -432,7 +432,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const string containerName = "DarkKnight";
             const string objectName = "BatmanBegins.jpg";
             var provider = new ObjectStoreProvider();
-            var objectHeadersResponse = provider.GetObjectHeaders(_testIdentity, containerName, objectName);
+            var objectHeadersResponse = provider.GetObjectHeaders(containerName, objectName, identity: _testIdentity);
 
             Assert.IsNotNull(objectHeadersResponse);
             //Assert.AreEqual("Christian Bale", objectHeadersResponse.Where(x => x.Key.Equals("X-Object-Meta-Actor", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
@@ -445,7 +445,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             string containerName = string.Empty;
             const string objectName = "BatmanBegins.jpg";
             var provider = new ObjectStoreProvider();
-            var objectHeadersResponse = provider.GetObjectHeaders(_testIdentity, containerName, objectName);
+            var objectHeadersResponse = provider.GetObjectHeaders(containerName, objectName, identity: _testIdentity);
 
             Assert.Fail("Expected exception was not thrown.");
         }
@@ -457,7 +457,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const string containerName = "DarkKnight";
             string objectName = string.Empty;
             var provider = new ObjectStoreProvider();
-            var objectHeadersResponse = provider.GetObjectHeaders(_testIdentity, containerName, objectName);
+            var objectHeadersResponse = provider.GetObjectHeaders(containerName, objectName, identity: _testIdentity);
 
             Assert.Fail("Expected exception was not thrown.");
         }
@@ -489,10 +489,10 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
                 Console.WriteLine(string.Format("{0:0.00} % Completed (Writen: {1} of {2})", percentCompleted, bytesWritten, totalBytest));
             });
 
-            var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
+            var containerGetObjectsResponse = provider.GetObjects(containerName, identity: _testIdentity);
             Assert.AreEqual(fileName, containerGetObjectsResponse.Where(x => x.Name.Equals(fileName, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Name);
 
-            var objectHeadersResponse = provider.GetObjectHeaders(_testIdentity, containerName, fileName);
+            var objectHeadersResponse = provider.GetObjectHeaders(containerName, fileName, identity: _testIdentity);
 
             Assert.IsNotNull(objectHeadersResponse);
             Assert.AreEqual(etag, objectHeadersResponse.Where(x => x.Key.Equals("ETag", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
@@ -523,7 +523,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             var provider = new ObjectStoreProvider(_testIdentity);
             provider.CreateObjectFromStream(containerName, stream, fileName, 65536, headers);
 
-            var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
+            var containerGetObjectsResponse = provider.GetObjects(containerName, identity: _testIdentity);
             Assert.AreEqual(fileName, containerGetObjectsResponse.Where(x => x.Name.Equals(fileName, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Name);
 
         }
@@ -555,10 +555,10 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
                 Console.WriteLine(string.Format("{0:0.00} % Completed (Writen: {1} of {2})", percentCompleted, bytesWritten, totalBytest));
             });
 
-            var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
+            var containerGetObjectsResponse = provider.GetObjects(containerName, identity: _testIdentity);
             Assert.AreEqual(fileName, containerGetObjectsResponse.Where(x => x.Name.Equals(fileName, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Name);
 
-            var objectHeadersResponse = provider.GetObjectHeaders(_testIdentity, containerName, fileName);
+            var objectHeadersResponse = provider.GetObjectHeaders(containerName, fileName, identity: _testIdentity);
 
             Assert.IsNotNull(objectHeadersResponse);
             Assert.AreEqual(etag, objectHeadersResponse.Where(x => x.Key.Equals("ETag", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
@@ -572,9 +572,9 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             string fileName = Path.GetFileName(filePath);
             var headers = new Dictionary<string, string>();
             var provider = new ObjectStoreProvider(_testIdentity);
-            provider.CreateObjectFromFile(containerName, filePath, fileName, 65536, headers);
+            provider.CreateObjectFromFile(containerName, filePath, fileName, 65536, headers, identity: _testIdentity);
 
-            var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
+            var containerGetObjectsResponse = provider.GetObjects(containerName, identity: _testIdentity);
             Assert.AreEqual(fileName, containerGetObjectsResponse.Where(x => x.Name.Equals(fileName, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Name);
 
         }
@@ -592,7 +592,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             var provider = new ObjectStoreProvider();
             provider.GetObjectSaveToFile(containerName, saveDirectory, fileName, null, 65536, null, null, false, _testIdentity);
 
-            //var containerGetObjectsResponse = provider.GetObjects(_testIdentity, containerName);
+            //var containerGetObjectsResponse = provider.GetObjects( containerName);
             //Assert.AreEqual(fileName, containerGetObjectsResponse.Where(x => x.Name.Equals(fileName, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Name);
 
         }
@@ -632,7 +632,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             string fileName = Path.GetFileName(filePath);
             var headers = new Dictionary<string, string>();
             var provider = new ObjectStoreProvider();
-            var deleteResponse = provider.DeleteObject(_testIdentity, containerName, fileName, headers);
+            var deleteResponse = provider.DeleteObject(containerName, fileName, headers, identity: _testIdentity);
 
             Assert.AreEqual(ObjectStore.ObjectDeleted, deleteResponse);
         }
@@ -648,7 +648,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             string fileName = Path.GetFileName(filePath);
             var headers = new Dictionary<string, string>();
             var provider = new ObjectStoreProvider();
-            var deleteResponse = provider.DeleteObject(_testIdentity, containerName, fileName, headers);
+            var deleteResponse = provider.DeleteObject(containerName, fileName, headers, identity: _testIdentity);
 
             Assert.Fail("Expected exception was not thrown.");
         }
@@ -663,7 +663,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             const string destinationObjectName = "BatmanBegins.jpg";
 
             var provider = new ObjectStoreProvider();
-            var copyResponse = provider.CopyObject(_testIdentity, sourceContainerName, sourceObjectName, destinationContainerName, destinationObjectName);
+            var copyResponse = provider.CopyObject(sourceContainerName, sourceObjectName, destinationContainerName, destinationObjectName, identity: _testIdentity);
 
             Assert.AreEqual(ObjectStore.ObjectCreated, copyResponse);
         }
@@ -681,7 +681,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             header.Add(ObjectStoreConstants.ContentLength, "62504");
 
             var provider = new ObjectStoreProvider();
-            var copyResponse = provider.CopyObject(_testIdentity, sourceContainerName, sourceObjectName, destinationContainerName, destinationObjectName, header);
+            var copyResponse = provider.CopyObject(sourceContainerName, sourceObjectName, destinationContainerName, destinationObjectName, header, identity: _testIdentity);
 
             Assert.AreEqual(ObjectStore.ObjectCreated, copyResponse);
         }
@@ -701,7 +701,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             header.Add(ObjectStoreConstants.ObjectDeleteAt, epoch.ToString());
 
             var provider = new ObjectStoreProvider();
-            var copyResponse = provider.CopyObject(_testIdentity, sourceContainerName, sourceObjectName, destinationContainerName, destinationObjectName, header);
+            var copyResponse = provider.CopyObject(sourceContainerName, sourceObjectName, destinationContainerName, destinationObjectName, header, identity: _testIdentity);
 
             Assert.AreEqual(ObjectStore.ObjectCreated, copyResponse);
 
@@ -719,6 +719,45 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
             //Assert.AreEqual("Christian Bale", objectHeadersResponse.Where(x => x.Key.Equals("X-Object-Meta-Actor", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value);
         }
 
+        [TestMethod]
+        public void Should_Purge_CDN_Enabled_Object_No_Email_Notification()
+        {
+            const string containerName = "DarkKnight";
+            const string objectName = "BatmanBegins.jpg";
+            var provider = new ObjectStoreProvider();
+            var objectDeleteResponse = provider.PurgeObjectFromCDN(containerName, objectName, identity: _testIdentity);
+
+            Assert.AreEqual(ObjectStore.ObjectPurged, objectDeleteResponse);
+            
+        }
+
+        [TestMethod]
+        public void Should_Purge_CDN_Enabled_Object_Single_Email_Notification()
+        {
+            const string containerName = "DarkKnight";
+            const string objectName = "TheDarkKnight.jpg";
+            const string emailTo = "123@abc.com";
+
+            var provider = new ObjectStoreProvider();
+            var objectDeleteResponse = provider.PurgeObjectFromCDN(containerName, objectName, email:emailTo, identity: _testIdentity);
+
+            Assert.AreEqual(ObjectStore.ObjectPurged, objectDeleteResponse);
+
+        }
+
+        [TestMethod]
+        public void Should_Purge_CDN_Enabled_Object_Multiple_Email_Notification()
+        {
+            const string containerName = "DarkKnight";
+            const string objectName = "TheDarkKnight.jpg";
+             var emailTo = new[]{"abc@123.com,123@abc.com"};
+
+            var provider = new ObjectStoreProvider();
+            var objectDeleteResponse = provider.PurgeObjectFromCDN(containerName, objectName, emailTo, identity: _testIdentity);
+
+            Assert.AreEqual(ObjectStore.ObjectPurged, objectDeleteResponse);
+
+        }
 
         #endregion Object Tests
 


### PR DESCRIPTION
**Stories:**
https://www.pivotaltracker.com/story/show/47573637
https://www.pivotaltracker.com/story/show/43555165

Added functionality for purging CDN enabled object. One method with 3 different signatures. ( **_No**_ email notification, **_Single**_ email notification, **_Multiple**_ email notification)

Also moved **CloudIdentity** as the last parameter in **ObjectStoreProvider** methods and made it optional.  
