### PR TITLE
[Delivers #43555163] CDN Streaming Container functionality

### DIFF
--- a/src/corelib/Core/Domain/ContainerCDN.cs
+++ b/src/corelib/Core/Domain/ContainerCDN.cs
@@ -29,5 +29,9 @@ namespace net.openstack.Core.Domain
 
         [DataMember(Name = "cdn_uri")]
         public string CDNUri { get; set; }
+
+        [DataMember(Name = "cdn_ios_uri")]
+        public string CDNIosUri { get; set; }
+
     }
 }

--- a/src/corelib/Core/ICloudFilesProvider.cs
+++ b/src/corelib/Core/ICloudFilesProvider.cs
@@ -17,7 +17,7 @@ namespace net.openstack.Core
         ObjectStore DeleteContainer(string container, string region = null, CloudIdentity identity = null);
         Dictionary<string, string> GetContainerHeader(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
         Dictionary<string, string> GetContainerMetaData(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
-        Dictionary<string, string> GetContainerCDNHeader(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
+        ContainerCDN GetContainerCDNHeader(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null);
 
         IEnumerable<ContainerCDN> ListCDNContainers(int? limit = null, string markerId = null, string markerEnd = null, bool cdnEnabled = false, string region = null, CloudIdentity identity = null);
 

--- a/src/corelib/Providers/Rackspace/CloudFilesConstants.cs
+++ b/src/corelib/Providers/Rackspace/CloudFilesConstants.cs
@@ -32,7 +32,8 @@ namespace net.openstack.Providers.Rackspace
         public const string CdnStreamingUri = "x-cdn-streaming-uri";
         public const string CdnTTL = "x-ttl";
         public const string CdnLogRetention = "x-log-retention";
-        public const string CdnEnabled = "X-Cdn-Enabled";
+        public const string CdnEnabled = "x-cdn-enabled";
+        public const string CdnIosUri = "x-cdn-ios-uri";
         //Object Constants
         public const string ObjectMetaDataPrefix = "x-object-meta-";
         public const string ObjectDeleteAfter = "x-delete-after";

--- a/src/testing/integration/Providers/Rackspace/CloudFilesTests.cs
+++ b/src/testing/integration/Providers/Rackspace/CloudFilesTests.cs
@@ -287,8 +287,8 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
 
             var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(containerName, identity: _testIdentity);
 
-            Assert.AreEqual(1000, int.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Ttl", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
-            Assert.IsTrue(bool.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Cdn-Enabled", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
+            Assert.AreEqual(1000, cdnContainerHeaderResponse.Ttl);
+            Assert.IsTrue(cdnContainerHeaderResponse.CDNEnabled);
 
         }
 
@@ -301,9 +301,11 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
 
             var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(containerName, identity: _testIdentity);
 
-            Assert.AreEqual(259200, int.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Ttl", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
-            Assert.IsTrue(bool.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Log-Retention", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
-            Assert.IsTrue(bool.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Cdn-Enabled", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
+            Assert.AreEqual(259200, cdnContainerHeaderResponse.Ttl);
+            Assert.IsTrue(cdnContainerHeaderResponse.LogRetention);
+            Assert.IsTrue(cdnContainerHeaderResponse.CDNEnabled);
+            Assert.IsTrue(!string.IsNullOrWhiteSpace(cdnContainerHeaderResponse.CDNIosUri));
+            Assert.IsTrue(containerName.Equals(cdnContainerHeaderResponse.Name,StringComparison.InvariantCultureIgnoreCase));
 
         }
 
@@ -316,7 +318,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
 
             var cdnContainerHeaderResponse = provider.GetContainerCDNHeader(containerName, identity: _testIdentity);
 
-            Assert.IsFalse(bool.Parse(cdnContainerHeaderResponse.Where(x => x.Key.Equals("X-Cdn-Enabled", StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault().Value));
+            Assert.IsFalse(cdnContainerHeaderResponse.CDNEnabled);
         }
 
         [TestMethod]


### PR DESCRIPTION
**Story:***
https://www.pivotaltracker.com/story/show/43555163

Method `GetContainerCDNHeader()` already existed but was returning `Dictionary<string,string>` changed it to return `ContainerCDN`.

Added **_x-cdn-ios-uri**_ to `ContainerCDN`, updated integration tests.

Removed private method `IsContainerCdnEnabled()` since we don't have to parse header value to find out if a container is CDN Enabled, now we can do `ContainerCDN().CDNEnabled`
