### PR TITLE
[Delivers #47720523] Add comments to the CloudBlockStorageProviders and updated a few of the integration tests

### DIFF
--- a/src/corelib/Core/ICloudBlockStorageProvider.cs
+++ b/src/corelib/Core/ICloudBlockStorageProvider.cs
@@ -1,23 +1,211 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using net.openstack.Core.Domain;
 
 namespace net.openstack.Core
 {
     public interface ICloudBlockStorageProvider
     {
+        #region Volume
+        /// <summary>
+        /// Creates a new volume.
+        /// 
+        /// Documentation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/POST_createVolume__v1__tenant_id__volumes.html
+        /// </summary>
+        /// <param name="size">The size (in GB) of the volume.  The size parameter should always be supplied and should be between 100 and 1000.</param>
+        /// <param name="display_description">A description of the volume.<remarks>[Optional]</remarks></param>
+        /// <param name="display_name">The name of the volume.<remarks>[Optional]</remarks></param>
+        /// <param name="snapshot_id">The optional snapshot from which to create a volume.<remarks>[Optional]</remarks></param>
+        /// <param name="volume_type">The type of volume to create, either SATA or SSD. If not defined, then the default, SATA, is used.<remarks>[Optional]</remarks></param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <exception cref="net.openstack.Providers.Rackspace.Exceptions.InvalidVolumeSizeException"></exception>
+        /// <returns><see cref="bool"></see></returns>
         bool CreateVolume(int size, string display_description = null, string display_name = null, string snapshot_id = null, string volume_type = null, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// View a list of volumes.
+        /// 
+        /// Documenatation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/GET_getVolumesSimple__v1__tenant_id__volumes.html
+        /// </summary>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns>List of <see cref="net.openstack.Core.Domain.Volume"></see> objects.</returns>
         IEnumerable<Volume> ListVolumes(string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// View all information about a single volume.
+        /// 
+        /// Documenatation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/GET_getVolume__v1__tenant_id__volumes.html
+        /// </summary>
+        /// <param name="volume_id">The ID of the volume</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="net.openstack.Core.Domain.Volume"></see></returns>
         Volume ShowVolume(string volume_id, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// Deletes a volume.
+        /// 
+        /// NOTE: 
+        /// It is not currently possible to delete a volume once you have created a snapshot from it.  Any snapshots will need to be deleted prior to deleting the Volume.
+        /// 
+        /// Documentation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/DELETE_deleteVolume__v1__tenant_id__volumes.html
+        /// </summary>
+        /// <param name="volume_id">The ID of the volume.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="bool"></see></returns>
         bool DeleteVolume(string volume_id, string region = null, CloudIdentity identity = null);
-
+        /// <summary>
+        /// Request a list of volume types.
+        /// 
+        /// Documentation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/GET_getVolumeTypes__v1__tenant_id__types.html
+        /// </summary>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns>List of <see cref="net.openstack.Core.Domain.VolumeType"></see> objects. </returns>
         IEnumerable<VolumeType> ListVolumeTypes(string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// Request a single volume type.
+        /// 
+        /// Documentation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/GET_getVolumeType__v1__tenant_id__types.html
+        /// </summary>
+        /// <param name="volume_type_id">The ID of the volume type.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="net.openstack.Core.Domain.VolumeType"></see></returns>
         VolumeType DescribeVolumeType(int volume_type_id, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// Waits for a volume to be set to "available" status.  
+        /// This method is designed to wait for a volume to move to "available" status after the CreateVolume method is called.  This method
+        /// will be helpful to ensure that a volume is correctly created prior to executing additional requests against it.
+        /// </summary>
+        /// <param name="volume_id">The ID of the volume to poll.</param>
+        /// <param name="refreshCount">The number of times to poll for the volume to become "available".</param>
+        /// <param name="refreshDelayInMS">The refresh delay in milliseconds.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="net.openstack.Core.Domain.Volume"></see></returns>
+        Volume WaitForVolumeAvailable(string volume_id, int refreshCount = 600, int refreshDelayInMS = 2400, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// Waits for a volume to be deleted.  
+        /// This method is designed to wait for a volume to be completely deleted after the DeleteVolume method is called.  
+        /// This method will be helpful to ensure that a volume is completely removed.
+        /// </summary>
+        /// <param name="volume_id">The ID of the volume to poll.</param>
+        /// <param name="refreshCount">The number of times to poll for the volume to be deleted.</param>
+        /// <param name="refreshDelayInMS">The refresh delay in milliseconds.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="bool"></see></returns>
+        bool WaitForVolumeDeleted(string volume_id, int refreshCount = 360, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// Waits for a volume to be set to be set to a particular status.  
+        /// This method is designed to wait for a volume to move to a particular status.  
+        /// This method will be helpful to ensure that a volume is in an intended state prior to executing additional requests against it.
+        /// 
+        /// Volume State reference URL:  http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/volume_status.html
+        /// <see cref="net.openstack.Core.Domain.VolumeState"></see>
+        /// </summary>
+        /// <param name="volume_id">The ID of the volume to poll.</param>
+        /// <param name="expectedState">The expected state for the volume.</param>
+        /// <param name="errorStates">The error state(s) in which to stop polling once reached.</param>
+        /// <param name="refreshCount">The number of times to poll the volume.</param>
+        /// <param name="refreshDelayInMS">The refresh delay in milliseconds.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="net.openstack.Core.Domain.Volume"></see></returns>
+        /// <exception cref="net.openstack.Providers.Rackspace.CloudBlockStorageProvider.VolumeEnteredErrorStateException"></exception>
+        Volume WaitForVolumeState(string volume_id, string expectedState, string[] errorStates, int refreshCount = 600, int refreshDelayInMS = 2400, string region = null, CloudIdentity identity = null);
+        #endregion
 
+        #region Snapshot
+        /// <summary>
+        /// Creates a new snapshot.
+        /// 
+        /// Creating a snapshot makes a point-in-time copy of the volume. 
+        /// All writes to the volume should be flushed before creating the snapshot, either by un-mounting any file systems on the volume, or by detaching the volume before creating the snapshot. 
+        /// Snapshots are incremental, so each time you create a new snapshot, you are appending the incremental changes for the new snapshot to the previous one. 
+        /// The previous snapshot is still available. Note that you can create a new volume from the snapshot if desired.
+
+        /// Documentation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/POST_createSnapshot__v1__tenant_id__snapshots.html
+        /// </summary>
+        /// <param name="volume_id">The ID of the volume to snapshot.</param>
+        /// <param name="force">Indicates whether to snapshot, even if the volume is attached. Default==False.<remarks>[Optional]</remarks></param>
+        /// <param name="display_name">Name of the snapshot. Default==None. <remarks>[Optional]</remarks></param>
+        /// <param name="display_description">Description of snapshot. Default==None.<remarks>[Optional]</remarks></param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="bool"></see></returns>
         bool CreateSnapshot(string volume_id, bool force = false, string display_name = "None", string display_description = null, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// View a list of snapshots.
+        /// 
+        /// Documenatation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/GET_getSnapshotsSimple__v1__tenant_id__snapshots.html
+        /// </summary>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns>List of <see cref="net.openstack.Core.Domain.Snapshot"></see> objects.</returns>
         IEnumerable<Snapshot> ListSnapshots(string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// View all information about a single snapshot.
+        /// 
+        /// Documenatation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/GET_getSnapshot__v1__tenant_id__snapshots.html
+        /// </summary>
+        /// <param name="snapshot_id">The ID of the snapshot</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="net.openstack.Core.Domain.Snapshot"></see></returns>
         Snapshot ShowSnapshot(string snapshot_id, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// Deletes a single snapshot.
+        /// 
+        /// Documentation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/DELETE_deleteSnapshot__v1__tenant_id__snapshots.html
+        /// </summary>
+        /// <param name="snapshot_id">The ID of the snapshot.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="bool"></see></returns>
         bool DeleteSnapshot(string snapshot_id, string region = null, CloudIdentity identity = null);
-
-
+        /// <summary>
+        /// Waits for a snapshot to be set to "available" status.  
+        /// This method is designed to wait for a snapshot to move to "available" status after the CreateSnapshot method is called.  
+        /// This method will be helpful to ensure that a snapshot is correctly created prior to executing additional requests against it.
+        /// </summary>
+        /// <param name="snapshot_id">The ID of the snapshot to poll.</param>
+        /// <param name="refreshCount">The number of times to poll for the snapshot to become "available".</param>
+        /// <param name="refreshDelayInMS">The refresh delay in milliseconds.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="net.openstack.Core.Domain.Snapshot"></see></returns>
+        Snapshot WaitForSnapshotAvailable(string snapshot_id, int refreshCount = 360, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// Waits for a snapshot to be deleted.  
+        /// This method is designed to wait for a snapshot to be completely deleted after the DeleteSnapshot method is called.  
+        /// This method will be helpful to ensure that a snapshot is completely removed.
+        /// </summary>
+        /// <param name="snapshot_id">The ID of the snapshot to poll.</param>
+        /// <param name="refreshCount">The number of times to poll for the snapshot to be deleted.</param>
+        /// <param name="refreshDelayInMS">The refresh delay in milliseconds.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="bool"></see></returns>
+        bool WaitForSnapshotDeleted(string snapshot_id, int refreshCount = 180, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null);
+        /// <summary>
+        /// Waits for a snapshot to be set to be set to a particular status.  
+        /// This method is designed to wait for a snapshot to move to a particular status.  
+        /// This method will be helpful to ensure that a snapshot is in an intended state prior to executing additional requests against it.
+        /// 
+        /// <see cref="net.openstack.Core.Domain.SnapshotState"></see> 
+        /// </summary>
+        /// <param name="snapshot_id">The ID of the snapshot to poll.</param>
+        /// <param name="expectedState">The expected state for the snapshot.</param>
+        /// <param name="errorStates">The error state(s) in which to stop polling once reached.</param>
+        /// <param name="refreshCount">The number of times to poll the snapshot.</param>
+        /// <param name="refreshDelayInMS">The refresh delay in milliseconds.</param>
+        /// <param name="region">The region in which to build the server.<remarks>[Optional]: If not specified, the users default region will be used.</remarks></param>
+        /// <param name="identity">The users Cloud Identity <see cref="net.openstack.Core.Domain.CloudIdentity"/><remarks>[Optional]: If not specified, the default identity given in the constructor will be used.</remarks></param>
+        /// <returns><see cref="net.openstack.Core.Domain.Snapshot"></see></returns>
+        /// <exception cref="net.openstack.Providers.Rackspace.CloudBlockStorageProvider.SnapshotEnteredErrorStateException"></exception>
+        Snapshot WaitForSnapshotState(string snapshot_id, string expectedState, string[] errorStates, int refreshCount = 60, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null);
+        #endregion
     }
 }

--- a/src/corelib/Providers/Rackspace/CloudBlockStorageProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudBlockStorageProvider.cs
@@ -14,29 +14,55 @@ using CreateCloudBlockStorageVolumeDetails = net.openstack.Providers.Rackspace.O
 
 namespace net.openstack.Providers.Rackspace
 {
+    /// <summary>
+    /// The Cloud Block Storage Provider contains the methods required to interact with Cloud Block Storage Volumes as well as Cloud Block Storage Volume Snapshots
+    /// Rackspace Cloud Block Storage is a block level storage solution that allows customers to mount drives or volumes to their Rackspace Next Generation Cloud Servers.
+    /// The two primary use cases are (1) to allow customers to scale their storage independently from their compute resources,
+    /// and (2) to allow customers to utilize high performance storage to serve database or I/O-intensive applications.
+    /// 
+    /// Highlights of Rackspace Cloud Block Storage include:
+    /// - Mount a drive to a Cloud Server to scale storage without paying for more compute capability.
+    /// - A high performance option for databases and high performance applications, leveraging solid state drives for speed.
+    /// - A standard speed option for customers who just need additional storage on their Cloud Server.
+    /// 
+    /// Notes:
+    /// - Cloud Block Storage is an add-on feature to Next Generation Cloud Servers.  Customers may not attach Cloud Block Storage volumes to other instances, like first generation Cloud Servers.
+    /// - Cloud Block Storage is multi-tenant rather than dedicated.
+    /// - When volumes are destroyed, Rackspace keeps that disk space unavailable until zeros have been written to the space to ensure that data is not accessible by any other customers.
+    /// - Cloud Block Storage allows you to create snapshots that you can save, list, and restore.
+    /// 
+    /// Documentation URL: http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/overview.html
+    /// </summary>
     public class CloudBlockStorageProvider : ProviderBase, ICloudBlockStorageProvider
     {
 
         private readonly int[] _validResponseCode = new[] { 200, 201, 202 };
         private readonly ICloudBlockStorageValidator _cloudBlockStorageValidator;
 
+        /// <summary>
+        /// Creates a new instance of the Rackspace <see cref="net.openstack.Providers.Rackspace.CloudBlockStorageProvider"/> class.
+        /// </summary>
         public CloudBlockStorageProvider()
             : this(null) { }
 
-        public CloudBlockStorageProvider(CloudIdentity defaultIdentity)
-            : this(defaultIdentity, new CloudIdentityProvider(), new JsonRestServices(), new CloudBlockStorageValidator()) { }
+        /// <summary>
+        /// Creates a new instance of the Rackspace <see cref="net.openstack.Providers.Rackspace.CloudBlockStorageProvider"/> class.
+        /// </summary>
+        /// <param name="identity">An instance of a <see cref="net.openstack.Core.Domain.CloudIdentity"/> object.<remarks>[Optional]: If not provided, the user will be required to pass a <see cref="net.openstack.Core.Domain.CloudIdentity"/> object to each method individually.</remarks></param>
+        public CloudBlockStorageProvider(CloudIdentity identity)
+            : this(identity, new CloudIdentityProvider(), new JsonRestServices(), new CloudBlockStorageValidator()) { }
 
         internal CloudBlockStorageProvider(ICloudIdentityProvider identityProvider, IRestService restService, ICloudBlockStorageValidator cloudBlockStorageValidator)
             : this(null, identityProvider, restService, cloudBlockStorageValidator) { }
 
-        internal CloudBlockStorageProvider(CloudIdentity defaultIdentity, ICloudIdentityProvider identityProvider, IRestService restService, ICloudBlockStorageValidator cloudBlockStorageValidator)
-            : base(defaultIdentity, identityProvider, restService)
+        internal CloudBlockStorageProvider(CloudIdentity identity, ICloudIdentityProvider identityProvider, IRestService restService, ICloudBlockStorageValidator cloudBlockStorageValidator)
+            : base(identity, identityProvider, restService)
         {
             _cloudBlockStorageValidator = cloudBlockStorageValidator;
         }
 
-
         #region Volumes
+
 
         public bool CreateVolume(int size, string display_description = null, string display_name = null, string snapshot_id = null, string volume_type = null, string region = null, CloudIdentity identity = null)
         {
@@ -101,12 +127,17 @@ namespace net.openstack.Providers.Rackspace
             return response.Data.VolumeType;
         }
 
-        public Volume WaitForVolumeAvailable(string volume_id, string region = null, int refreshCount = 600, int refreshDelayInMS = 2400, CloudIdentity identity = null)
+        public Volume WaitForVolumeAvailable(string volume_id, int refreshCount = 600, int refreshDelayInMS = 2400, string region = null, CloudIdentity identity = null)
         {
-            return WaitForVolumeState(volume_id, VolumeState.AVAILABLE, new[] { VolumeState.ERROR, VolumeState.ERROR_DELETING }, region, refreshCount, refreshDelayInMS, identity);
+            return WaitForVolumeState(volume_id, VolumeState.AVAILABLE, new[] { VolumeState.ERROR, VolumeState.ERROR_DELETING }, refreshCount, refreshDelayInMS, region, identity);
         }
-       
-        public Volume WaitForVolumeState(string volume_id, string expectedState, string[] errorStates, string region = null, int refreshCount = 600, int refreshDelayInMS = 2400, CloudIdentity identity = null)
+
+        public bool WaitForVolumeDeleted(string volume_id, int refreshCount = 360, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null)
+        {
+            return WaitForItemToBeDeleted(ShowVolume, volume_id, refreshCount, refreshDelayInMS, region, identity);
+        }
+
+        public Volume WaitForVolumeState(string volume_id, string expectedState, string[] errorStates, int refreshCount = 600, int refreshDelayInMS = 2400, string region = null, CloudIdentity identity = null)
         {
             var volumeInfo = ShowVolume(volume_id, region, identity);
 
@@ -139,7 +170,7 @@ namespace net.openstack.Providers.Rackspace
 
         #region Snapshots
 
-        public bool CreateSnapshot(string volume_id, bool force = false, string display_name = "None", string display_description = null, string region = null, CloudIdentity identity = null)
+        public bool CreateSnapshot(string volume_id, bool force = false, string display_name = "None", string display_description = "None", string region = null, CloudIdentity identity = null)
         {
             var urlPath = new Uri(string.Format("{0}/snapshots", GetServiceEndpoint(identity, region)));
             var requestBody = new CreateCloudBlockStorageSnapshotRequest { CreateCloudBlockStorageSnapshotDetails = new CreateCloudBlockStorageSnapshotDetails { VolumeId = volume_id, Force = force, DisplayName = display_name, DisplayDescription = display_description } };
@@ -170,6 +201,7 @@ namespace net.openstack.Providers.Rackspace
             return response.Data.Snapshot;
         }
 
+
         public bool DeleteSnapshot(string snapshot_id, string region = null, CloudIdentity identity = null)
         {
             var urlPath = new Uri(string.Format("{0}/snapshots/{1}", GetServiceEndpoint(identity, region), snapshot_id));
@@ -178,44 +210,32 @@ namespace net.openstack.Providers.Rackspace
             return response != null && _validResponseCode.Contains(response.StatusCode);
         }
 
-        public Snapshot WaitForSnapshotAvailable(string snapshot_id, string region = null, int refreshCount = 180, int refreshDelayInMS = 10000, CloudIdentity identity = null)
+        public Snapshot WaitForSnapshotAvailable(string snapshot_id, int refreshCount = 360, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null)
         {
-            return WaitForSnapshotState(snapshot_id, SnapshotState.AVAILABLE, new[] { SnapshotState.ERROR, SnapshotState.ERROR_DELETING }, region, refreshCount, refreshDelayInMS, identity);
+            return WaitForSnapshotState(snapshot_id, SnapshotState.AVAILABLE, new[] { SnapshotState.ERROR, SnapshotState.ERROR_DELETING }, refreshCount, refreshDelayInMS, region, identity);
         }
 
-        public bool WaitForSnapshotDeleted(string snapshot_id, string region = null, int refreshCount = 360, int refreshDelayInMS = 10000, CloudIdentity identity = null)
+        public bool WaitForSnapshotDeleted(string snapshot_id, int refreshCount = 180, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null)
         {
-            return WaitForSnapshotState(snapshot_id, "Deleted", new[] { SnapshotState.ERROR, SnapshotState.ERROR_DELETING }, region, refreshCount, refreshDelayInMS, identity) == null;
+            return WaitForItemToBeDeleted(ShowSnapshot, snapshot_id, refreshCount, refreshDelayInMS, region, identity);
         }
 
-        public Snapshot WaitForSnapshotState(string snapshot_id, string expectedState, string[] errorStates, string region = null, int refreshCount = 60, int refreshDelayInMS = 10000, CloudIdentity identity = null)
+        public Snapshot WaitForSnapshotState(string snapshot_id, string expectedState, string[] errorStates, int refreshCount = 60, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null)
         {
-            try
+            var snapshotInfo = ShowSnapshot(snapshot_id, region, identity);
+
+            var count = 0;
+            while (!snapshotInfo.Status.Equals(expectedState, StringComparison.OrdinalIgnoreCase) && !errorStates.Contains(snapshotInfo.Status) && count < refreshCount)
             {
-                var snapshotInfo = ShowSnapshot(snapshot_id, region, identity);
-
-                var count = 0;
-                while (!snapshotInfo.Status.Equals(expectedState, StringComparison.OrdinalIgnoreCase) && !errorStates.Contains(snapshotInfo.Status) && count < refreshCount)
-                {
-                    Thread.Sleep(refreshDelayInMS);
-                    snapshotInfo = ShowSnapshot(snapshot_id, region, identity);
-                    if (expectedState == "Deleted" && snapshotInfo == null)
-                    {
-                        return null;
-                    }
-                    count++;
-                }
-
-                if (errorStates.Contains(snapshotInfo.Status))
-                    throw new SnapshotEnteredErrorStateException(snapshotInfo.Status);
-
-                return snapshotInfo;
+                Thread.Sleep(refreshDelayInMS);
+                snapshotInfo = ShowSnapshot(snapshot_id, region, identity);
+                count++;
             }
-            catch (ItemNotFoundException)
-            {   
-                return null;
-            }
-            
+
+            if (errorStates.Contains(snapshotInfo.Status))
+                throw new SnapshotEnteredErrorStateException(snapshotInfo.Status);
+
+            return snapshotInfo;
         }
 
         public class SnapshotEnteredErrorStateException : Exception
@@ -236,6 +256,28 @@ namespace net.openstack.Providers.Rackspace
         protected string GetServiceEndpoint(CloudIdentity identity = null, string region = null)
         {
             return base.GetPublicServiceEndpoint(identity, "cloudBlockStorage", region);
+        }
+
+        private bool WaitForItemToBeDeleted<T>(Func<string, string, CloudIdentity, T> retrieveItemMethod, string id, int refreshCount = 360, int refreshDelayInMS = 10000, string region = null, CloudIdentity identity = null)
+        {
+            try
+            {
+                retrieveItemMethod(id, region, identity);
+
+                var count = 0;
+                while (count < refreshCount)
+                {
+                    Thread.Sleep(refreshDelayInMS);
+                    retrieveItemMethod(id, region, identity);
+                    count++;
+                }
+            }
+            catch (ItemNotFoundException)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         #endregion

--- a/src/corelib/Providers/Rackspace/Exceptions/InvalidVolumeSizeException.cs
+++ b/src/corelib/Providers/Rackspace/Exceptions/InvalidVolumeSizeException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace net.openstack.Providers.Rackspace.Exceptions
+{
+    public class InvalidVolumeSizeException : Exception
+    {
+        public int Size { get; private set; }
+
+        public InvalidVolumeSizeException(int size)
+            : base(string.Format("The volume size value must be between 100 and 1000.  The size requested was: {0}", size))
+        {
+            Size = size;
+        }
+    }
+}

--- a/src/corelib/Providers/Rackspace/Validators/CloudBlockStorageValidator.cs
+++ b/src/corelib/Providers/Rackspace/Validators/CloudBlockStorageValidator.cs
@@ -3,15 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using net.openstack.Core;
+using net.openstack.Providers.Rackspace.Exceptions;
 
 namespace net.openstack.Providers.Rackspace.Validators
 {
     public class CloudBlockStorageValidator : ICloudBlockStorageValidator
     {
         public void ValidateVolumeSize(int size)
-        {   
+        {
             if (size < 100 || size > 1000)
-                throw new ArgumentException("ERROR: The volume size value must be between 100 and 1000");
+                throw new InvalidVolumeSizeException(size);
         }
     }
 }

--- a/src/corelib/corelib.csproj
+++ b/src/corelib/corelib.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Providers\Rackspace\CloudFilesValidator.cs" />
     <Compile Include="Core\ICloudFilesValidator.cs" />
     <Compile Include="Providers\Rackspace\EncodeDecodeProvider.cs" />
+    <Compile Include="Providers\Rackspace\Exceptions\InvalidVolumeSizeException.cs" />
     <Compile Include="Providers\Rackspace\IExtendedCloudIdentityProvider.cs" />
     <Compile Include="Providers\Rackspace\Exceptions\InvalidETagException.cs" />
     <Compile Include="Providers\Rackspace\CloudFilesProvider.cs" />

--- a/src/testing/unit/Providers/Rackspace/CloudBlockStorageTests.cs
+++ b/src/testing/unit/Providers/Rackspace/CloudBlockStorageTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using net.openstack.Providers.Rackspace.Exceptions;
 using net.openstack.Providers.Rackspace.Validators;
 
 namespace OpenStackNet.Testing.Unit.Providers.Rackspace
@@ -17,7 +18,7 @@ namespace OpenStackNet.Testing.Unit.Providers.Rackspace
                 var cloudBlockStorageValidator = new CloudBlockStorageValidator();
                 cloudBlockStorageValidator.ValidateVolumeSize(size);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
 
                 Assert.Fail("Exception should not be thrown.");
@@ -33,12 +34,11 @@ namespace OpenStackNet.Testing.Unit.Providers.Rackspace
             {
                 var cloudBlockStorageValidator = new CloudBlockStorageValidator();
                 cloudBlockStorageValidator.ValidateVolumeSize(size);
-                Assert.Fail("Expected was not thrown.");
+                Assert.Fail("Expected exception was not thrown.");
             }
-            catch (Exception ex)
+            catch (Exception exc)
             {
-
-                Assert.AreEqual("ERROR: The volume size value must be between 100 and 1000", ex.Message);
+                Assert.IsTrue(exc is InvalidVolumeSizeException);
             }
         }
 
@@ -53,11 +53,10 @@ namespace OpenStackNet.Testing.Unit.Providers.Rackspace
                 cloudBlockStorageValidator.ValidateVolumeSize(size);
                 Assert.Fail("Expected  was not thrown.");
             }
-            catch (Exception ex)
+            catch (Exception exc)
             {
-
-                Assert.AreEqual("ERROR: The volume size value must be between 100 and 1000", ex.Message);
+                Assert.IsTrue(exc is InvalidVolumeSizeException);
             }
-        }    
+        }
     }
 }


### PR DESCRIPTION
**Summary**
- Added /// comments to each method in the provider as well as to each public constructor.
- Updated Volume size validator in CloudBlockStorageValidator to throw InvalidVolumeSizeException versus ArgumentException
- Updated tests and WaitFor{X}State methods

**Testing**
Ran full integration tests with changes incorporated.  
The full ordered test includes the following steps:
- Cleans up the environment
- Creates a volume
- Checks that the volume is there
- Creates a snapshot of the volume
- Checks that the snapshot is there
- Deletes the snapshot
- Verifies the snapshot is actually deleted [if this fails we cannot delete the volume]
- Deletes the volume
- Verifies the volume is actually deleted.
