### PR TITLE
[Delivers #48258531] ListObjects returns 404, Item not found exception when the container name has spaces

### DIFF
--- a/src/corelib/Core/IEncodeDecodeProvider.cs
+++ b/src/corelib/Core/IEncodeDecodeProvider.cs
@@ -7,7 +7,7 @@ namespace net.openstack.Core
 {
     public interface IEncodeDecodeProvider
     {
-        string HtmlEncode(string stringToEncode);
-        string HtmlDecode(string stringToDecode);
+        string UrlEncode(string stringToEncode);
+        string UrlDecode(string stringToDecode);
     }
 }

--- a/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
@@ -83,7 +83,7 @@ namespace net.openstack.Providers.Rackspace
         public ObjectStore CreateContainer(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _cloudFilesValidator.ValidateContainerName(container);
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.PUT);
 
@@ -98,7 +98,7 @@ namespace net.openstack.Providers.Rackspace
         public ObjectStore DeleteContainer(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _cloudFilesValidator.ValidateContainerName(container);
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.DELETE);
 
@@ -115,7 +115,7 @@ namespace net.openstack.Providers.Rackspace
         public Dictionary<string, string> GetContainerHeader(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _cloudFilesValidator.ValidateContainerName(container);
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.HEAD);
 
@@ -127,7 +127,7 @@ namespace net.openstack.Providers.Rackspace
         public Dictionary<string, string> GetContainerMetaData(string container, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _cloudFilesValidator.ValidateContainerName(container);
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.GET); // Should be HEAD
 
@@ -140,7 +140,7 @@ namespace net.openstack.Providers.Rackspace
         {
             _cloudFilesValidator.ValidateContainerName(container);
 
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.UrlEncode(container)));
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.HEAD);
 
             var result = new ContainerCDN { Name = container };
@@ -236,7 +236,7 @@ namespace net.openstack.Providers.Rackspace
                  {CdnLogRetention, logRetention.ToString(CultureInfo.InvariantCulture)},
                  {CdnEnabled, "true"}
                 };
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.UrlEncode(container)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.PUT, headers: headers);
 
@@ -254,7 +254,7 @@ namespace net.openstack.Providers.Rackspace
                 {
                 {CdnEnabled, "false"}
                 };
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.UrlEncode(container)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.PUT, headers: headers);
 
@@ -285,7 +285,7 @@ namespace net.openstack.Providers.Rackspace
                 }
             }
 
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container)));
 
             ExecuteRESTRequest(identity, urlPath, HttpMethod.POST, headers: headers);
         }
@@ -298,7 +298,7 @@ namespace net.openstack.Providers.Rackspace
                 throw new ArgumentNullException();
             }
 
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container)));
 
             ExecuteRESTRequest(identity, urlPath, HttpMethod.POST, headers: headers);
         }
@@ -316,7 +316,7 @@ namespace net.openstack.Providers.Rackspace
                 throw new CDNNotEnabledException();
             }
 
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.UrlEncode(container)));
             ExecuteRESTRequest(identity, urlPath, HttpMethod.POST, headers: headers);
         }
 
@@ -419,7 +419,7 @@ namespace net.openstack.Providers.Rackspace
         {
             _cloudFilesValidator.ValidateContainerName(container);
             _cloudFilesValidator.ValidateObjectName(objectName);
-            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container), _encodeDecodeProvider.HtmlEncode(objectName)));
+            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container), _encodeDecodeProvider.UrlEncode(objectName)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.HEAD);
 
@@ -432,7 +432,7 @@ namespace net.openstack.Providers.Rackspace
         {
             _cloudFilesValidator.ValidateContainerName(container);
             _cloudFilesValidator.ValidateObjectName(objectName);
-            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container), _encodeDecodeProvider.HtmlEncode(objectName)));
+            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container), _encodeDecodeProvider.UrlEncode(objectName)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.HEAD);
 
@@ -444,7 +444,7 @@ namespace net.openstack.Providers.Rackspace
         public IEnumerable<ContainerObject> ListObjects(string container, int? limit = null, string marker = null, string markerEnd = null, string region = null, bool useInternalUrl = false, CloudIdentity identity = null)
         {
             _cloudFilesValidator.ValidateContainerName(container);
-            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container)));
+            var urlPath = new Uri(string.Format("{0}/{1}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container)));
 
             var queryStringParameter = new Dictionary<string, string>();
 
@@ -483,10 +483,10 @@ namespace net.openstack.Providers.Rackspace
 
             if (stream.Length > LargeFileBatchThreshold)
             {
-                CreateObjectInSegments(_encodeDecodeProvider.HtmlEncode(container), stream, _encodeDecodeProvider.HtmlEncode(objectName), chunkSize, headers, region, progressUpdated, useInternalUrl, identity);
+                CreateObjectInSegments(_encodeDecodeProvider.UrlEncode(container), stream, _encodeDecodeProvider.UrlEncode(objectName), chunkSize, headers, region, progressUpdated, useInternalUrl, identity);
                 return;
             }
-            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container), _encodeDecodeProvider.HtmlEncode(objectName)));
+            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container), _encodeDecodeProvider.UrlEncode(objectName)));
 
             StreamRESTRequest(identity, urlPath, HttpMethod.PUT, stream, chunkSize, headers: headers, isRetry: true, progressUpdated: progressUpdated, requestSettings: new RequestSettings());
         }
@@ -496,7 +496,7 @@ namespace net.openstack.Providers.Rackspace
             _cloudFilesValidator.ValidateContainerName(container);
             _cloudFilesValidator.ValidateObjectName(objectName);
 
-            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container), _encodeDecodeProvider.HtmlEncode(objectName)));
+            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container), _encodeDecodeProvider.UrlEncode(objectName)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.GET, (resp, isError) =>
             {
@@ -590,7 +590,7 @@ namespace net.openstack.Providers.Rackspace
 
             headers.Add(CopyFrom, string.Format("{0}/{1}", sourceContainer, sourceObjectName));
 
-            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(destinationContainer), _encodeDecodeProvider.HtmlEncode(destinationObjectName)));
+            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(destinationContainer), _encodeDecodeProvider.UrlEncode(destinationObjectName)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.PUT, headers);
 
@@ -607,7 +607,7 @@ namespace net.openstack.Providers.Rackspace
             _cloudFilesValidator.ValidateContainerName(container);
             _cloudFilesValidator.ValidateObjectName(objectName);
 
-            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.HtmlEncode(container), _encodeDecodeProvider.HtmlEncode(objectName)));
+            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), _encodeDecodeProvider.UrlEncode(container), _encodeDecodeProvider.UrlEncode(objectName)));
 
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.DELETE, headers);
 
@@ -655,7 +655,7 @@ namespace net.openstack.Providers.Rackspace
             {
                 headers[CdnPurgeEmail] = email;
             }
-            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.HtmlEncode(container), _encodeDecodeProvider.HtmlEncode(objectName)));
+            var urlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFilesCDN(identity, region), _encodeDecodeProvider.UrlEncode(container), _encodeDecodeProvider.UrlEncode(objectName)));
             var response = ExecuteRESTRequest(identity, urlPath, HttpMethod.DELETE, headers: headers);
             if (response.StatusCode == 204)
                 return ObjectStore.ObjectPurged;

--- a/src/corelib/Providers/Rackspace/EncodeDecodeProvider.cs
+++ b/src/corelib/Providers/Rackspace/EncodeDecodeProvider.cs
@@ -9,14 +9,14 @@ namespace net.openstack.Providers.Rackspace
 {
     public class EncodeDecodeProvider : IEncodeDecodeProvider
     {
-        public string HtmlEncode(string stringToEncode)
+        public string UrlEncode(string stringToEncode)
         {
-            return HttpUtility.UrlEncode(stringToEncode);
+            return HttpUtility.UrlEncode(stringToEncode).Replace("+","%20");
         }
 
-        public string HtmlDecode(string stringToDecode)
+        public string UrlDecode(string stringToDecode)
         {
-            return HttpUtility.HtmlDecode(stringToDecode);
+            return HttpUtility.UrlDecode(stringToDecode);
         }
     }
 }

--- a/src/testing/integration/Providers/Rackspace/CloudFilesTests.cs
+++ b/src/testing/integration/Providers/Rackspace/CloudFilesTests.cs
@@ -18,7 +18,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
 
         private static RackspaceCloudIdentity _testIdentity;
 
-        private static readonly string containerName = string.Format("CloudFilesIntegrationTests_{0}",Guid.NewGuid().ToString());
+        private static readonly string containerName = string.Format("Cloud Files Integration Tests_{0}",Guid.NewGuid().ToString());
         const string webIndex = "index.html";
         const string webError = "error.html";
         const string webListingsCSS = "index.css";
@@ -30,7 +30,8 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         private const string sourceObjectName = objectName;
 
         private static readonly string destinationContainerName = string.Format("{0}_DarkKnightRises", containerName);
-        private const string destinationObjectName = objectName;
+        private const string destinationObjectName = "Test " + objectName;
+
 
         const string emailTo = "123@abc.com";
         string[] emailToList = new[] { "abc@123.com,123@abc.com" };
@@ -652,10 +653,9 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         [TestMethod]
         public void Should_Delete_Object_On_Destination_Container()
         {
-            string fileName = objectName;
             var headers = new Dictionary<string, string>();
             var provider = new CloudFilesProvider();
-            var deleteResponse = provider.DeleteObject(destinationContainerName, fileName, headers, identity: _testIdentity);
+            var deleteResponse = provider.DeleteObject(destinationContainerName, destinationObjectName, headers, identity: _testIdentity);
 
             Assert.AreEqual(ObjectStore.ObjectDeleted, deleteResponse);
         }

--- a/src/testing/unit/Providers/Rackspace/EncodeDecodeProviderTests.cs
+++ b/src/testing/unit/Providers/Rackspace/EncodeDecodeProviderTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using net.openstack.Providers.Rackspace;
+
+namespace OpenStackNet.Testing.Unit.Providers.Rackspace
+{
+    [TestClass]
+    public class EncodeDecodeProviderTests
+    {
+        [TestMethod]
+        public void Should_Encode_Spaces()
+        {
+            const string stringToBeEncoded = "This is a test with spaces";
+            var encodeDecodeProvider = new EncodeDecodeProvider();
+            var result = encodeDecodeProvider.UrlEncode(stringToBeEncoded);
+            Assert.AreEqual("This%20is%20a%20test%20with%20spaces", result);
+        }
+
+        [TestMethod]
+        public void Should_Decode_Spaces()
+        {
+            const string stringToBeDecoded = "This%20is%20a%20test%20with%20spaces";
+            var encodeDecodeProvider = new EncodeDecodeProvider();
+            var result = encodeDecodeProvider.UrlDecode(stringToBeDecoded);
+            Assert.AreEqual("This is a test with spaces", result);
+        }
+
+        [TestMethod]
+        public void Should_Encode_Special_Characters()
+        {
+            const string stringToBeEncoded = "This $ is & a ? test * with @ spaces";
+            var encodeDecodeProvider = new EncodeDecodeProvider();
+            var result = encodeDecodeProvider.UrlEncode(stringToBeEncoded);
+            Assert.AreEqual("This%20%24%20is%20%26%20a%20%3f%20test%20*%20with%20%40%20spaces", result);
+        }
+
+        [TestMethod]
+        public void Should_Decode_Special_Characters()
+        {
+            const string stringToBeEncoded = "This%20%24%20is%20%26%20a%20%3f%20test%20*%20with%20%40%20spaces";
+            var encodeDecodeProvider = new EncodeDecodeProvider();
+            var result = encodeDecodeProvider.UrlDecode(stringToBeEncoded);
+            Assert.AreEqual("This $ is & a ? test * with @ spaces", result);
+        }
+
+    }
+}

--- a/src/testing/unit/unit.csproj
+++ b/src/testing/unit/unit.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\Rackspace\CloudNetworksValidatorTests.cs" />
     <Compile Include="Providers\Rackspace\CloudBlockStorageTests.cs" />
+    <Compile Include="Providers\Rackspace\EncodeDecodeProviderTests.cs" />
     <Compile Include="Providers\Rackspace\IdentityProviderCacheTests.cs" />
     <Compile Include="Providers\Rackspace\ObjectProviderHelperTests.cs" />
   </ItemGroup>


### PR DESCRIPTION
**Story:**
https://www.pivotaltracker.com/story/show/48258531

This is a fix for URL encoding, were spaces are encoded as **+** instead of **%20**.
Bug reported here : https://github.com/rackspace/openstack.net/issues/70

Fixed DecodeEncodeProvider to replace + with %20 after UrlEncode method is called.

Created **unit tests** for DecodeEncodeProvider.

Modified integration tests to include a creation of **container with spaces** and ran the ordered tests.
