### PR TITLE
[Delivers #48506135] Fix Out of Memory error when uploading large files

### DIFF
--- a/src/corelib/Core/ICloudFilesProvider.cs
+++ b/src/corelib/Core/ICloudFilesProvider.cs
@@ -269,14 +269,14 @@ namespace net.openstack.Core
         /// </summary>
         /// <param name="container">The container name.</param>
         /// <param name="filePath">The file path.<remarks>Example c:\folder1\folder2\image_name.jpeg</remarks></param>
-        /// <param name="objectName">Name of the object.<remarks>Example image_name.jpeg</remarks></param>
+        /// <param name="objectName">Name of the object.<remarks>Example image_name.jpeg.  If null, the name of the upload file will be used</remarks></param>
         /// <param name="chunkSize">Chunk size.<remarks>[Default = 4096]</remarks> </param>
         /// <param name="headers">The headers. </param>
         /// <param name="region">The region in which to execute this action.<remarks>If not specified, the user’s default region will be used.</remarks></param>
         /// <param name="progressUpdated">The progress updated. <see cref="Action&lt;T&gt;"/> </param>
         /// <param name="useInternalUrl">If set to <c>true</c> uses ServiceNet URL.</param>
         /// <param name="identity">The users Cloud Identity. <see cref="CloudIdentity"/> <remarks>If not specified, the default identity given in the constructor will be used.</remarks> </param>
-        void CreateObjectFromFile(string container, string filePath, string objectName, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null, bool useInternalUrl = false, CloudIdentity identity = null);
+        void CreateObjectFromFile(string container, string filePath, string objectName = null, int chunkSize = 65536, Dictionary<string, string> headers = null, string region = null, Action<long> progressUpdated = null, bool useInternalUrl = false, CloudIdentity identity = null);
 
         /// <summary>
         /// Creates the object.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/48506135
### Changes
- Added the ChunkRequest = true to all requests to the SimpleRestServices stream methods.  This will caused the uploads to chunk and not buffer the whole stream.  
- Modified the objectName parameter in the CreateObjectFromFile to be optional (default to null).  If the value is null, it will just use the name of the file being uploaded.
