### PR TITLE
[Delivers #48917517] Fixed the issue for missing default regions in london

### DIFF
--- a/src/openstack.net.sln
+++ b/src/openstack.net.sln
@@ -5,24 +5,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "corelib", "corelib\corelib.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "console", "console\console.csproj", "{1C279666-B88A-4765-8A51-B352C85EFC28}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "integration", "testing\integration\integration.csproj", "{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DD863CE0-64D7-43AC-9DDD-C745B36CCD2C}"
-	ProjectSection(SolutionItems) = preProject
-		openstack.net.vsmdi = openstack.net.vsmdi
-		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testing", "testing", "{62B45D81-B643-4E2B-B612-F479B9570F3A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "unit", "testing\unit\unit.csproj", "{FDFD92C2-75CF-4437-87B8-841EC3624CE4}"
 EndProject
-Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation", "Documentation\Documentation.shfbproj", "{EA57BD15-3742-45B8-BDE2-263F7236BAFD}"
-EndProject
 Global
-	GlobalSection(TestCaseManagementSettings) = postSolution
-		CategoryFile = openstack.net.vsmdi
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
@@ -52,16 +39,6 @@ Global
 		{1C279666-B88A-4765-8A51-B352C85EFC28}.Release|Mixed Platforms.Build.0 = Release|x86
 		{1C279666-B88A-4765-8A51-B352C85EFC28}.Release|x86.ActiveCfg = Release|x86
 		{1C279666-B88A-4765-8A51-B352C85EFC28}.Release|x86.Build.0 = Release|x86
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|x86.ActiveCfg = Release|Any CPU
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -72,21 +49,11 @@ Global
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Release|x86.ActiveCfg = Release|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4} = {62B45D81-B643-4E2B-B612-F479B9570F3A}
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4} = {62B45D81-B643-4E2B-B612-F479B9570F3A}
 	EndGlobalSection
 EndGlobal

--- a/src/openstack.net_2012.sln
+++ b/src/openstack.net_2012.sln
@@ -1,18 +1,9 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "corelib", "corelib\corelib.csproj", "{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "console", "console\console.csproj", "{1C279666-B88A-4765-8A51-B352C85EFC28}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "integration", "testing\integration\integration.csproj", "{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DD863CE0-64D7-43AC-9DDD-C745B36CCD2C}"
-	ProjectSection(SolutionItems) = preProject
-		Local.testsettings = Local.testsettings
-		openstack.net.vsmdi = openstack.net.vsmdi
-		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testing", "testing", "{62B45D81-B643-4E2B-B612-F479B9570F3A}"
 EndProject
@@ -51,16 +42,6 @@ Global
 		{1C279666-B88A-4765-8A51-B352C85EFC28}.Release|Mixed Platforms.Build.0 = Release|x86
 		{1C279666-B88A-4765-8A51-B352C85EFC28}.Release|x86.ActiveCfg = Release|x86
 		{1C279666-B88A-4765-8A51-B352C85EFC28}.Release|x86.Build.0 = Release|x86
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|x86.ActiveCfg = Release|Any CPU
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -76,7 +57,6 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4} = {62B45D81-B643-4E2B-B612-F479B9570F3A}
 		{FDFD92C2-75CF-4437-87B8-841EC3624CE4} = {62B45D81-B643-4E2B-B612-F479B9570F3A}
 	EndGlobalSection
 EndGlobal

--- a/src/openstack.net_Documentation.sln
+++ b/src/openstack.net_Documentation.sln
@@ -1,0 +1,42 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "corelib", "corelib\corelib.csproj", "{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation", "Documentation\Documentation.shfbproj", "{EA57BD15-3742-45B8-BDE2-263F7236BAFD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|x86.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/openstack.net_Integration_Tests.sln
+++ b/src/openstack.net_Integration_Tests.sln
@@ -1,0 +1,56 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "corelib", "corelib\corelib.csproj", "{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "integration", "testing\integration\integration.csproj", "{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DD863CE0-64D7-43AC-9DDD-C745B36CCD2C}"
+	ProjectSection(SolutionItems) = preProject
+		openstack.net.vsmdi = openstack.net.vsmdi
+		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testing", "testing", "{62B45D81-B643-4E2B-B612-F479B9570F3A}"
+EndProject
+Global
+	GlobalSection(TestCaseManagementSettings) = postSolution
+		CategoryFile = openstack.net.vsmdi
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{7DBA11EB-DBA7-4D3A-8D42-B5312E74B9C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4}.Release|x86.ActiveCfg = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C1D0D0D8-9EF2-4557-B85F-34FDB0F466C4} = {62B45D81-B643-4E2B-B612-F479B9570F3A}
+	EndGlobalSection
+EndGlobal

--- a/src/testing/unit/Providers/Rackspace/ProviderBaseTests.cs
+++ b/src/testing/unit/Providers/Rackspace/ProviderBaseTests.cs
@@ -1,0 +1,284 @@
+﻿using System;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+using JSIStudios.SimpleRESTServices.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Moq.Protected;
+using net.openstack.Core;
+using net.openstack.Core.Domain;
+using net.openstack.Providers.Rackspace;
+
+namespace OpenStackNet.Testing.Unit.Providers.Rackspace
+{
+    [TestClass]
+    public class ProviderBaseTests
+    {
+        private const string _testService = "test";
+
+        [TestMethod]
+        public void Should_Return_Correct_Endpoint_When_Identity_Is_Explicitly_Set_And_Region_Is_Explicitly_Declared()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "DFW" }, new Endpoint { Region = "ORD" } } } },
+                    User = new UserDetails { DefaultRegion = "DFW" }
+                });
+            var provider = new MockProvider(null, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, "DFW", new CloudIdentity());
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("DFW", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_Endpoint_When_Identity_Is_Explicitly_Set_And_Region_Is_Different_Than_Default_Region()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "DFW" }, new Endpoint { Region = "ORD" } } } },
+                    User = new UserDetails { DefaultRegion = "DFW" }
+                });
+            var provider = new MockProvider(null, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, "ORD", new CloudIdentity());
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("ORD", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_Endpoint_When_Identity_Set_On_Provider_And_Region_Is_Different_Than_Default_Region()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "DFW" }, new Endpoint { Region = "ORD" } } } },
+                    User = new UserDetails { DefaultRegion = "DFW" }
+                });
+            var provider = new MockProvider(new CloudIdentity(), identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, "ORD", null);
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("ORD", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_Endpoint_When_Identity_Is_Explicitly_Set_And_Region_Is_NOT_Explicitly_Declared()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "DFW" }, new Endpoint { Region = "ORD" } } } },
+                    User = new UserDetails { DefaultRegion = "DFW" }
+                });
+            var provider = new MockProvider(null, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, null, new CloudIdentity());
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("DFW", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_Endpoint_When_Identity_Is_Set_On_Provider_And_Region_Is_Explicitly_Declared()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "DFW" }, new Endpoint { Region = "ORD" } } } },
+                    User = new UserDetails { DefaultRegion = "DFW" }
+                });
+            var provider = new MockProvider(new CloudIdentity(), identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, "DFW", null);
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("DFW", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_Endpoint_When_Identity_Is_Set_On_Provider_And_Region_Is_NOT_Explicitly_Declared()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "DFW" }, new Endpoint { Region = "ORD" } } } },
+                    User = new UserDetails { DefaultRegion = "DFW" }
+                });
+            var provider = new MockProvider(new CloudIdentity(), identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, null, null);
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("DFW", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_LON_Endpoint_When_Identity_Is_Explicitly_Set_And_Region_Is_Explicitly_Declared()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "LON" }, new Endpoint { Region = "LON2" } } } },
+                    User = new UserDetails { DefaultRegion = "LON" }
+                });
+            var provider = new MockProvider(null, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, "LON", new RackspaceCloudIdentity {CloudInstance = CloudInstance.UK});
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("LON", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_LON_Endpoint_When_Identity_Is_Explicitly_Set_And_Region_Is_NOT_Explicitly_Declared()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "LON" }, new Endpoint { Region = "LON2" } } } },
+                    User = new UserDetails { DefaultRegion = "LON" }
+                });
+            var provider = new MockProvider(null, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, null, new RackspaceCloudIdentity {CloudInstance = CloudInstance.UK});
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("LON", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_LON_Endpoint_When_Identity_Is_Set_On_Provider_And_Region_Is_Explicitly_Declared()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "LON" }, new Endpoint { Region = "LON2" } } } },
+                    User = new UserDetails { DefaultRegion = "LON" }
+                });
+            var provider = new MockProvider(new RackspaceCloudIdentity {CloudInstance = CloudInstance.UK}, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, "LON", null);
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("LON", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_LON_Endpoint_When_Identity_Is_Set_On_Provider_And_Region_Is_NOT_Explicitly_Declared()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "LON" }, new Endpoint { Region = "LON2" } } } },
+                    User = new UserDetails { DefaultRegion = "LON" }
+                });
+            var provider = new MockProvider(new RackspaceCloudIdentity {CloudInstance = CloudInstance.UK}, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, null, null);
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("LON", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_LON_Endpoint_When_Identity_Is_Explicitly_And_Region_Is_Always_Empty()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "LON" }, new Endpoint { Region = "LON2" } } } },
+                    User = new UserDetails { DefaultRegion = "" }
+                });
+            var provider = new MockProvider(null, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, null, new RackspaceCloudIdentity { CloudInstance = CloudInstance.UK });
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("LON", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_LON_Endpoint_When_Identity_Is_Set_On_Provider_And_Region_Is_Always_Empty()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "LON" }, new Endpoint { Region = "LON2" } } } },
+                    User = new UserDetails { DefaultRegion = "" }
+                });
+            var provider = new MockProvider(new RackspaceCloudIdentity { CloudInstance = CloudInstance.UK }, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, null, null);
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("LON", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_LON_Endpoint_When_Identity_Is_Explicitly_And_Region_Is_Always_Null()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "LON" }, new Endpoint { Region = "LON2" } } } },
+                    User = new UserDetails { DefaultRegion = null }
+                });
+            var provider = new MockProvider(null, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, null, new RackspaceCloudIdentity { CloudInstance = CloudInstance.UK });
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("LON", endpoint.Region);
+        }
+
+        [TestMethod]
+        public void Should_Return_Correct_LON_Endpoint_When_Identity_Is_Set_On_Provider_And_Region_Is_Always_Null()
+        {
+            var identityProviderMock = new Mock<ICloudIdentityProvider>();
+            identityProviderMock.Setup(m => m.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(
+                new UserAccess
+                {
+                    ServiceCatalog = new[] { new ServiceCatalog() { Name = _testService, Endpoints = new[] { new Endpoint { Region = "LON" }, new Endpoint { Region = "LON2" } } } },
+                    User = new UserDetails { DefaultRegion = null }
+                });
+            var provider = new MockProvider(new RackspaceCloudIdentity { CloudInstance = CloudInstance.UK }, identityProviderMock.Object, null);
+
+            var endpoint = provider.GetEndpoint(_testService, null, null);
+
+            Assert.IsNotNull(endpoint);
+            Assert.AreEqual("LON", endpoint.Region);
+        }
+
+        public class MockProvider : ProviderBase
+        {
+            internal MockProvider(CloudIdentity defaultIdentity, ICloudIdentityProvider identityProvider, IRestService restService) : base(defaultIdentity, identityProvider, restService)
+            {
+            }
+
+            public Endpoint GetEndpoint(string serviceName, string region, CloudIdentity identity)
+            {
+                return base.GetServiceEndpoint(identity, serviceName, region);
+            }
+        }
+    }
+}

--- a/src/testing/unit/unit.csproj
+++ b/src/testing/unit/unit.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Providers\Rackspace\EncodeDecodeProviderTests.cs" />
     <Compile Include="Providers\Rackspace\IdentityProviderCacheTests.cs" />
     <Compile Include="Providers\Rackspace\ObjectProviderHelperTests.cs" />
+    <Compile Include="Providers\Rackspace\ProviderBaseTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
### Fixes
- https://www.pivotaltracker.com/story/show/48917517
- https://github.com/rackspace/openstack.net/issues/81
### Changes
- Added a check to the provider base to explicitly set the region to **LON** when the following are all satisfied:
  - There is no region passed into the method
  - There is no default region retruned from the identity service
  - The identity is of type **RackspaceCloudIdentity** and has the **CloudInstance** = UK
- Removed the integration tests from the main .sln file, and moved them to their own .sln file _openstack.net_Integration_Tests.sln_
- Removed the documentation project from the main .sln file, and moved it to its own .sln file _openstack.net_Documentation.sln_
