### PR TITLE
Concurrent UserAccessCache

### DIFF
--- a/src/corelib/Core/Caching/UserAccessCache.cs
+++ b/src/corelib/Core/Caching/UserAccessCache.cs
@@ -7,6 +7,8 @@ namespace net.openstack.Core.Caching
 {
     public class UserAccessCache : ICache<UserAccess>
     {
+        private static readonly Lazy<UserAccessCache> _instance = new Lazy<UserAccessCache>(CreateInstance, true);
+
         private readonly ConcurrentDictionary<string, UserAccess> _tokenCache = new ConcurrentDictionary<string, UserAccess>();
 
         public UserAccess Get(string key, Func<UserAccess> refreshCallback, bool forceCacheRefresh = false)
@@ -62,24 +64,17 @@ namespace net.openstack.Core.Caching
             return userAccess;
         }
 
-        private static volatile UserAccessCache _instance;
-        private static object _contextLock = new object();
-
         public static UserAccessCache Instance
         {
             get
             {
-                if (_instance == null)
-                {
-                    lock (_contextLock)
-                    {
-                        if(_instance == null)
-                            _instance = new UserAccessCache();
-                    }
-                }
-
-                return _instance;
+                return _instance.Value;
             }
+        }
+
+        private static UserAccessCache CreateInstance()
+        {
+            return new UserAccessCache();
         }
 
         private static bool IsValid(UserAccess userAccess)


### PR DESCRIPTION
This pull request improves concurrent access to the `UserAccessCache` instance by removing the exclusive locks in favor of `ConcurrentDictionary` and `Lazy<T>`.

This pull request preserves the following behavior of the original code. This behavior is potentially unintended/unwanted but I figured I'm not in the correct place to make that determination.

When `forceCacheRefresh` is false _and_ `refreshCallback` is null _and_ the existing `UserAccess` instance is non-null and no longer valid (`userAccess.Token` is null or `IsExpired()` returns true), the function removes the value from the cache but instead of returning `null` it returns the existing value which was removed. The desired behavior may be to instead return null since the value was removed.
