### PR TITLE
Cleanup IObjectStorageMetadataProcessor

### DIFF
--- a/src/corelib/Core/IObjectStorageMetadataProcessor.cs
+++ b/src/corelib/Core/IObjectStorageMetadataProcessor.cs
@@ -16,10 +16,22 @@ namespace net.openstack.Core
         /// the type of metadata, and the values are key-value collections of the corresponding
         /// metadata.
         /// </summary>
+        /// <remarks>
+        /// <note type="implement">
+        /// The resulting metadata dictionaries should use the <see cref="StringComparer.OrdinalIgnoreCase"/>
+        /// equality comparer to ensure lookups are not case sensitive.
+        /// </note>
+        /// </remarks>
         /// <param name="httpHeaders">The collection of HTTP headers.</param>
         /// <returns>The metadata.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="httpHeaders"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="httpHeaders"/> contains two headers with equivalent values for <see cref="HttpHeader.Key"/> (case-insensitive).</exception>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="httpHeaders"/> contains any <c>null</c> values.
+        /// <para>-or-</para>
+        /// <para>If <paramref name="httpHeaders"/> contains any values with a null or empty <see cref="HttpHeader.Key"/>.</para>
+        /// <para>-or-</para>
+        /// <para>If <paramref name="httpHeaders"/> contains two headers with equivalent values for <see cref="HttpHeader.Key"/> when compared using <see cref="StringComparer.OrdinalIgnoreCase"/>.</para>
+        /// </exception>
         Dictionary<string, Dictionary<string, string>> ProcessMetadata(IList<HttpHeader> httpHeaders);
     }
 }


### PR DESCRIPTION
- More explicit `IObjectStorageMetadataProcessor` documentation
- Updated `CloudFilesMetadataProcessor` to use `StringComparer.OrdinalIgnoreCase` (fixes #126)
- Updated `CloudFilesMetadataProcessor` to use `string.Length` property instead of magic numbers
- Updated `CloudFilesMetadataProcessor` to use `StartsWith` instead of `Contains`
