### PR TITLE
ValidateToken updates

### DIFF
--- a/src/corelib/Core/Providers/IIdentityProvider.cs
+++ b/src/corelib/Core/Providers/IIdentityProvider.cs
@@ -27,6 +27,22 @@ namespace net.openstack.Core.Providers
         UserAccess Authenticate(CloudIdentity identity = null);
 
         /// <summary>
+        /// Validates a given token.
+        /// </summary>
+        /// <param name="token">The token to be validated.</param>
+        /// <param name="tenantId">If specified, the validation ensures that the specified tenant is in scope. This is obtained from <see cref="Tenant.Id"/>.</param>
+        /// <param name="identity">The cloud identity to use for this request. If not specified, the default identity for the current provider instance will be used.</param>
+        /// <returns>A <see cref="UserAccess"/> object containing the authentication token and user data. The <see cref="UserAccess.ServiceCatalog"/> property of the result may be <c>null</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="token"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="token"/> is empty.</exception>
+        /// <exception cref="NotSupportedException">If the provider does not support the given <paramref name="identity"/> type.</exception>
+        /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <c>null</c> and no default identity is available for the provider.</exception>
+        /// <exception cref="ItemNotFoundException">If <paramref name="tenantId"/> is specified and the token is not valid within the specified tenant.</exception>
+        /// <exception cref="ResponseException">If the authentication request failed or the token does not exist.</exception>
+        /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/GET_validateToken_v2.0_tokens__tokenId__Token_Operations.html">Validate Token (OpenStack Identity Service API v2.0 Reference)</seealso>
+        UserAccess ValidateToken(string token, string tenantId = null, CloudIdentity identity = null);
+
+        /// <summary>
         /// Gets the authentication token for the specified identity. If necessary, the identity is authenticated
         /// on the server to obtain a token.
         /// </summary>

--- a/src/corelib/Providers/Rackspace/IExtendedCloudIdentityProvider.cs
+++ b/src/corelib/Providers/Rackspace/IExtendedCloudIdentityProvider.cs
@@ -349,21 +349,5 @@ namespace net.openstack.Providers.Rackspace
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
         /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/POST_updateUserCredential_v2.0_users__userId__OS-KSADM_credentials__credential-type__.html">Update User Credentials (OpenStack Identity Service API v2.0 Reference)</seealso>
         UserCredential UpdateUserCredentials(string userId, string username, string apiKey, CloudIdentity identity = null);
-
-        /// <summary>
-        /// Validates a given token.
-        /// </summary>
-        /// <param name="token">The token to be authenticated.</param>
-        /// <param name="tenantId">If specified, the validation ensures that the specified tenant is in scope. This is obtained from <see cref="Tenant.Id"/>.</param>
-        /// <param name="identity">The cloud identity to use for this request. If not specified, the default identity for the current provider instance will be used.</param>
-        /// <returns>A <see cref="UserAccess"/> object containing the authentication token and user data. The <see cref="UserAccess.ServiceCatalog"/> property of the result may be <c>null</c>.</returns>
-        /// <exception cref="ArgumentNullException">If <paramref name="token"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">If <paramref name="token"/> is empty.</exception>
-        /// <exception cref="NotSupportedException">If the provider does not support the given <paramref name="identity"/> type.</exception>
-        /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <c>null</c> and no default identity is available for the provider.</exception>
-        /// <exception cref="ItemNotFoundException">If <paramref name="tenantId"/> is specified and the token is not valid within the specified tenant.</exception>
-        /// <exception cref="ResponseException">If the authentication request failed or the token does not exist.</exception>
-        /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/GET_validateToken_v2.0_tokens__tokenId__Token_Operations.html">Validate Token (OpenStack Identity Service API v2.0 Reference)</seealso>
-        UserAccess ValidateToken(string token, string tenantId = null, CloudIdentity identity = null);
     }
 }

--- a/src/testing/integration/Providers/Rackspace/UserIdentityTests.cs
+++ b/src/testing/integration/Providers/Rackspace/UserIdentityTests.cs
@@ -69,7 +69,7 @@
         }
 
         /// <summary>
-        /// This method tests the basic functionality of the <see cref="IExtendedCloudIdentityProvider.ValidateToken"/>
+        /// This method tests the basic functionality of the <see cref="IIdentityProvider.ValidateToken"/>
         /// method for a validated token.
         /// </summary>
         [TestMethod]
@@ -77,7 +77,7 @@
         [TestCategory(TestCategories.Identity)]
         public void TestValidateToken()
         {
-            IExtendedCloudIdentityProvider provider = new CloudIdentityProvider(Bootstrapper.Settings.TestIdentity);
+            IIdentityProvider provider = new CloudIdentityProvider(Bootstrapper.Settings.TestIdentity);
             UserAccess userAccess = provider.Authenticate();
 
             Assert.IsNotNull(userAccess);


### PR DESCRIPTION
- Updated documentation for `ValidateToken`
- Move `ValidateToken` to `IIdentityProvider` since it's documented in the OpenStack Identity Service API.
