### PR TITLE
Fix CreateServer ignoring the networks parameter (fixes rackspace#39)

### DIFF
--- a/src/corelib/Core/Providers/IComputeProvider.cs
+++ b/src/corelib/Core/Providers/IComputeProvider.cs
@@ -143,6 +143,8 @@ namespace net.openstack.Core.Providers
         /// <para><paramref name="flavor"/> is empty.</para>
         /// <para>-or-</para>
         /// <para><paramref name="metadata"/> contains a value with a null or empty key.</para>
+        /// <para>-or-</para>
+        /// <para><paramref name="networks"/> contains a null or empty value.</para>
         /// </exception>
         /// <exception cref="NotSupportedException">
         /// If the provider does not support the given <paramref name="diskConfig"/>.
@@ -158,7 +160,7 @@ namespace net.openstack.Core.Providers
         /// </exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
         /// <seealso href="http://docs.openstack.org/api/openstack-compute/2/content/CreateServers.html">Create Server (OpenStack Compute API v2 and Extensions Reference)</seealso>
-        NewServer CreateServer(string cloudServerName, string imageName, string flavor, DiskConfiguration diskConfig = null, Metadata metadata = null, Personality[] personality = null, bool attachToServiceNetwork = false, bool attachToPublicNetwork = false, IEnumerable<Guid> networks = null, string region = null, CloudIdentity identity = null);
+        NewServer CreateServer(string cloudServerName, string imageName, string flavor, DiskConfiguration diskConfig = null, Metadata metadata = null, Personality[] personality = null, bool attachToServiceNetwork = false, bool attachToPublicNetwork = false, IEnumerable<string> networks = null, string region = null, CloudIdentity identity = null);
 
         /// <summary>
         /// Gets the detailed information for a specific server.

--- a/src/corelib/Providers/Rackspace/CloudServersProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudServersProvider.cs
@@ -173,7 +173,7 @@ namespace net.openstack.Providers.Rackspace
         }
 
         /// <inheritdoc />
-        public NewServer CreateServer(string cloudServerName, string imageName, string flavor, DiskConfiguration diskConfig = null, Metadata metadata = null, Personality[] personality = null, bool attachToServiceNetwork = false, bool attachToPublicNetwork = false, IEnumerable<Guid> networks = null, string region = null, CloudIdentity identity = null)
+        public NewServer CreateServer(string cloudServerName, string imageName, string flavor, DiskConfiguration diskConfig = null, Metadata metadata = null, Personality[] personality = null, bool attachToServiceNetwork = false, bool attachToPublicNetwork = false, IEnumerable<string> networks = null, string region = null, CloudIdentity identity = null)
         {
             if (cloudServerName == null)
                 throw new ArgumentNullException("cloudServerName");
@@ -187,6 +187,8 @@ namespace net.openstack.Providers.Rackspace
                 throw new ArgumentException("imageName cannot be empty");
             if (string.IsNullOrEmpty(flavor))
                 throw new ArgumentException("flavor cannot be empty");
+            if (networks != null && networks.Any(string.IsNullOrEmpty))
+                throw new ArgumentException("networks cannot contain any null or empty values");
             if (diskConfig != null && diskConfig != DiskConfiguration.Auto && diskConfig != DiskConfiguration.Manual)
                 throw new NotSupportedException("The specified disk configuration is not supported.");
             CheckIdentity(identity);
@@ -202,6 +204,9 @@ namespace net.openstack.Providers.Rackspace
                 if(attachToServiceNetwork)
                     networksToAttach.Add("11111111-1111-1111-1111-111111111111");
             }
+
+            if (networks != null)
+                networksToAttach.AddRange(networks);
 
             const string accessIPv4 = null;
             const string accessIPv6 = null;

--- a/src/testing/integration/Providers/Rackspace/CloudNetworksTests.cs
+++ b/src/testing/integration/Providers/Rackspace/CloudNetworksTests.cs
@@ -125,7 +125,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         public void Should_Create_A_Server_With_New_Network_And_Wait_For_Active()
         {
             var provider = new CloudServersProvider(_testIdentity);
-            var networks = new List<Guid>() { new Guid(_created_network_id2) };
+            var networks = new List<string>() { _created_network_id2 };
             var testServer = provider.CreateServer("net-sdk-test-server", "d531a2dd-7ae9-4407-bb5a-e5ea03303d98", "2", networks: networks);
 
             Assert.IsNotNull(testServer.Id);


### PR DESCRIPTION
As reported in rackspace#39, the `CreateServer` implementation was ignoring the `networks` parameter. This change does the following:
- Changes the `networks` parameter from `IEnumerable<Guid>` to `IEnumerable<string>` to more closely match the API, especially since the matching `CloudNetwork.Id` property is already `string`
- Checks that `networks` does not contain `null` or the empty strings
- If `networks` is not `null`, adds the specified networks to the `networksToAttach` list (no longer ignoring the parameter)

**Breaking Change**

After this change is merged, code which calls `CreateServer` will need to be recompiled against the new SDK release. In addition, code which uses the `networks` parameter will need to be updated to use `IEnumerable<string>` instead of `IEnumerable<Guid>`.
