### PR TITLE
Added Support for the RAX-AUTH:authenticatedBy token property

### DIFF
--- a/src/corelib/Core/Domain/AuthenticationType.cs
+++ b/src/corelib/Core/Domain/AuthenticationType.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Newtonsoft.Json;
+
+namespace net.openstack.Core.Domain
+{
+    /// <summary>
+    /// Represents the way a user has authenticated.
+    /// </summary>
+    /// <remarks>
+    /// This class functions as a strongly-typed enumeration of known authentication types,
+    /// with added support for unknown types returned by a server extension.
+    /// </remarks>
+    /// <threadsafety static="true" instance="false"/>
+    /// <preliminary/>
+    [JsonConverter(typeof(AuthenticationType.Converter))]
+    public class AuthenticationType : ExtensibleEnum<AuthenticationType>
+    {
+        private static readonly ConcurrentDictionary<string, AuthenticationType> _types =
+            new ConcurrentDictionary<string, AuthenticationType>(StringComparer.OrdinalIgnoreCase);
+
+        private static readonly AuthenticationType _password = FromName("PASSWORD");
+        private static readonly AuthenticationType _rsa = FromName("RSAKEY");
+
+        private AuthenticationType(string name) : base(name)
+        {
+        }
+
+        /// <summary>
+        /// Gets the <see cref="AuthenticationType"/> instance with the specified name.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="name"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="name"/> is empty.</exception>
+        public static AuthenticationType FromName(string name)
+        {
+            if (name == null)
+                throw new ArgumentNullException("name");
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentException("name cannot be empty");
+
+            return _types.GetOrAdd(name, i => new AuthenticationType(i));
+        }
+
+        /// <summary>
+        /// Gets an <see cref="AuthenticationType"/> representing that a user authenticated using a password.
+        /// </summary>
+        public static AuthenticationType Password
+        {
+            get
+            {
+                return _password;
+            }
+        }
+
+        /// <summary>
+        /// Gets an <see cref="AuthenticationType"/> representing that a user authenticated using an RSA key.
+        /// </summary>
+        public static AuthenticationType RSA
+        {
+            get
+            {
+                return _rsa;
+            }
+        }
+
+        /// <summary>
+        /// Provides support for serializing and deserializing <see cref="AuthenticationType"/> objects to JSON string values.
+        /// </summary>
+        /// <threadsafety static="true" instance="false"/>
+        /// <preliminary/>
+        private sealed class Converter : ConverterBase
+        {
+            /// <inheritdoc/>
+            protected override AuthenticationType FromName(string name)
+            {
+                return AuthenticationType.FromName(name);
+            }
+        }
+    }
+}

--- a/src/corelib/Core/Domain/IdentityToken.cs
+++ b/src/corelib/Core/Domain/IdentityToken.cs
@@ -3,6 +3,7 @@
     using System;
     using net.openstack.Core.Providers;
     using Newtonsoft.Json;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Represents the authentication token used for making authenticated calls to
@@ -51,5 +52,13 @@
                 return expiration <= DateTimeOffset.Now;
             }
         }
+
+        /// <summary>
+        /// Gets a Collection of <see cref="AuthenticationType"/> objects representing the ways the 
+        /// user has authenticated.
+        /// </summary>
+        /// <preliminary/>
+        [JsonProperty("RAX-AUTH:authenticatedBy", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public IEnumerable<AuthenticationType> AuthenticationTypes { get; private set; } 
     }
 }

--- a/src/corelib/corelib.v3.5.csproj
+++ b/src/corelib/corelib.v3.5.csproj
@@ -197,6 +197,7 @@
     <Compile Include="Providers\Rackspace\ILoadBalancerService.cs" />
     <Compile Include="Providers\Rackspace\NamespaceDoc.cs" />
     <Compile Include="Providers\Rackspace\Objects\ArchiveFormat.cs" />
+    <Compile Include="Core\Domain\AuthenticationType.cs" />
     <Compile Include="Providers\Rackspace\Objects\BulkDeletionFailedObject.cs" />
     <Compile Include="Providers\Rackspace\Objects\BulkDeletionResults.cs" />
     <Compile Include="Providers\Rackspace\Objects\Dns\DnsChange.cs" />

--- a/src/corelib/corelib.v4.0.csproj
+++ b/src/corelib/corelib.v4.0.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Core\Caching\ICache`1.cs" />
     <Compile Include="Core\Caching\NamespaceDoc.cs" />
     <Compile Include="Core\Domain\AuthenticationRequirement.cs" />
+    <Compile Include="Core\Domain\AuthenticationType.cs" />
     <Compile Include="Core\Domain\Converters\NamespaceDoc.cs" />
     <Compile Include="Core\Domain\Converters\PhysicalAddressSimpleConverter.cs" />
     <Compile Include="Core\Domain\Converters\SimpleStringJsonConverter`1.cs" />

--- a/src/testing/integration/Bootstrapper.cs
+++ b/src/testing/integration/Bootstrapper.cs
@@ -85,7 +85,7 @@ namespace Net.OpenStack.Testing.Integration
 
         public ExtendedCloudIdentity TestAdminIdentity { get; set; }
 
-        public ExtendedCloudIdentity TestDomainIdentity { get; set; }
+        public ExtendedRackspaceCloudIdentity TestDomainIdentity { get; set; }
 
         public string RackspaceExtendedIdentityUrl { get; set; }
 
@@ -106,6 +106,11 @@ namespace Net.OpenStack.Testing.Integration
     public class ExtendedRackspaceCloudIdentity : RackspaceCloudIdentity
     {
         public string TenantId { get; set; }
+
+        public ExtendedRackspaceCloudIdentity()
+        {
+            
+        }
 
         public ExtendedRackspaceCloudIdentity(ExtendedCloudIdentity cloudIdentity)
         {

--- a/src/testing/integration/Providers/Rackspace/ExtendedIdentityTests.cs
+++ b/src/testing/integration/Providers/Rackspace/ExtendedIdentityTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using net.openstack.Core.Caching;
 using net.openstack.Core.Domain;
 using net.openstack.Core.Exceptions.Response;
-using net.openstack.Core.Providers;
 using net.openstack.Providers.Rackspace;
 using net.openstack.Providers.Rackspace.Objects;
 
@@ -16,7 +15,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         private TestContext testContextInstance;
         private static RackspaceCloudIdentity _testIdentity;
         private static RackspaceCloudIdentity _testAdminIdentity;
-        private static ExtendedRackspaceCloudIdentity _testDomainIdentity;
+        private static RackspaceCloudIdentity _testDomainIdentity;
         private static User _userDetails;
         private static User _adminUserDetails;
         private const string NewPassword = "My_n3w_p@$$w0rd";
@@ -42,7 +41,7 @@ namespace Net.OpenStack.Testing.Integration.Providers.Rackspace
         {
             _testIdentity = new RackspaceCloudIdentity(Bootstrapper.Settings.TestIdentity);
             _testAdminIdentity = new RackspaceCloudIdentity(Bootstrapper.Settings.TestAdminIdentity);
-            _testDomainIdentity = new ExtendedRackspaceCloudIdentity(Bootstrapper.Settings.TestDomainIdentity);
+            _testDomainIdentity = new RackspaceCloudIdentity(Bootstrapper.Settings.TestDomainIdentity);
 
             var provider = BuildProvider();
 

--- a/src/testing/integration/Providers/Rackspace/UserIdentityTests.cs
+++ b/src/testing/integration/Providers/Rackspace/UserIdentityTests.cs
@@ -464,7 +464,7 @@
             Assert.AreEqual(identity, provider.DefaultIdentity);
 
             IIdentityProvider defaultProvider = Bootstrapper.CreateIdentityProvider();
-            Assert.IsNull(defaultProvider.DefaultIdentity);
+            Assert.IsNotNull(defaultProvider.DefaultIdentity);
         }
     }
 }


### PR DESCRIPTION
- Added support for the list of authentication types that are returned on the token object from the Rackspace identity service for supporting Domains.  
- Fixed the DomainTestUser to extend from the RackspaceCloudIdentity object to allow for proper testing of the Domain authentication.
- Fixed a incorrect assertion in `UserIdentityTests.TestDefaultIdentity()` method which caused the test to fail
