### PR TITLE
Adding ".seg" to X-Object-Manifest value (fixed #268)

### DIFF
--- a/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
@@ -1723,7 +1723,7 @@ namespace net.openstack.Providers.Rackspace
 
             // upload the manifest file
             Uri segmentUrlPath = new Uri(string.Format("{0}/{1}/{2}", GetServiceEndpointCloudFiles(identity, region, useInternalUrl), UriUtility.UriEncode(container, UriPart.AnyUrl, Encoding.UTF8), UriUtility.UriEncode(objectName, UriPart.AnyUrl, Encoding.UTF8)));
-            string objectManifestValue = string.Format("{1}.seg", objectName);
+            string objectManifestValue = string.Format("{0}.seg", objectName);
 
             if (headers == null)
                 headers = new Dictionary<string, string>();


### PR DESCRIPTION
The Openstack Proxy server needs to list out just the segments when it computes the ETag in response to a GET/HEAD on a manifest file. If the X-Object-Manifest is just the object name the Proxy server matches the segments and the manifest which cause the Proxy to create a bad ETag
