### PR TITLE
Added return type to message post for queue service

### DIFF
--- a/src/corelib/Core/Domain/Queues/MessagesEnqueued.cs
+++ b/src/corelib/Core/Domain/Queues/MessagesEnqueued.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using net.openstack.Core.Providers;
+using Newtonsoft.Json;
+
+namespace net.openstack.Core.Domain.Queues
+{
+    /// <summary>
+    /// Represents the response returned when enqueueing messages in the <see cref="IQueueingService"/>
+    /// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class MessagesEnqueued : QueuedMessageBase
+    {
+#pragma warning disable 649 // Field 'fieldName' is never assigned to, and will always have its default value {value}
+        /// <summary>
+        /// Specifies whether the enqueue was only partially successful. 
+        /// Successfully enqueued messages are listed under <see cref="_resources"/>
+        /// </summary>
+        [JsonProperty("partial")]
+        private bool _partial;
+
+        /// <summary>
+        /// Contains a collection of message resource URIs.
+        /// </summary>
+        [JsonProperty("resources")]
+        private IEnumerable<Uri> _resources;
+#pragma warning restore 649
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MessagesEnqueued"/>
+        /// during JSON deserialization.
+        /// </summary>
+        [JsonConstructor]
+        protected MessagesEnqueued()
+        {
+        }
+
+        /// <summary>
+        /// Gets the posted message IDs.
+        /// </summary>
+        public IEnumerable<MessageId> Ids
+        {
+            get
+            {
+                if (_resources == null) 
+                    yield break;
+
+                foreach (var resource in _resources)
+                {
+                    yield return ParseMessageId(resource);
+                }
+            }
+        }
+    }
+}

--- a/src/corelib/Core/Domain/Queues/QueuedMessage.cs
+++ b/src/corelib/Core/Domain/Queues/QueuedMessage.cs
@@ -12,7 +12,7 @@
     /// <threadsafety static="true" instance="false"/>
     /// <preliminary/>
     [JsonObject(MemberSerialization.OptIn)]
-    public class QueuedMessage
+    public class QueuedMessage : QueuedMessageBase
     {
 #pragma warning disable 649 // Field 'fieldName' is never assigned to, and will always have its default value {value}
         /// <summary>
@@ -61,15 +61,7 @@
                 if (Href == null)
                     return null;
 
-                Uri href = Href;
-                // make sure we have an absolute URI, or Segments will throw an InvalidOperationException
-                if (!href.IsAbsoluteUri)
-                    href = new Uri(new Uri("http://example.com"), href);
-
-                if (href.Segments.Length == 0)
-                    return null;
-
-                return new MessageId(href.Segments.Last());
+                return ParseMessageId(Href);
             }
         }
 

--- a/src/corelib/Core/Domain/Queues/QueuedMessageBase.cs
+++ b/src/corelib/Core/Domain/Queues/QueuedMessageBase.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+
+namespace net.openstack.Core.Domain.Queues
+{
+    /// <summary>
+    /// Contains common methods used across queue message domain objects.
+    /// </summary>
+    public abstract class QueuedMessageBase
+    {
+        /// <summary>
+        /// Parses a URI to extract a <see cref="MessageId"/>.
+        /// </summary>
+        /// <param name="href">The resource URI.</param>
+        /// <returns>The ID of the message.</returns>
+        protected MessageId ParseMessageId(Uri href)
+        {
+            // make sure we have an absolute URI, or Segments will throw an InvalidOperationException
+            if (!href.IsAbsoluteUri)
+                href = new Uri(new Uri("http://example.com"), href);
+
+            if (href.Segments.Length == 0)
+                return null;
+
+            return new MessageId(href.Segments.Last());
+        }
+    }
+}

--- a/src/corelib/Core/Providers/IQueueingService.cs
+++ b/src/corelib/Core/Providers/IQueueingService.cs
@@ -342,7 +342,7 @@
         /// </exception>
         /// <exception cref="WebException">If the REST request does not return successfully.</exception>
         /// <seealso href="https://wiki.openstack.org/w/index.php?title=Marconi/specs/api/v1#Post_Message.28s.29">Post Message(s) (OpenStack Marconi API v1 Blueprint)</seealso>
-        Task PostMessagesAsync(QueueName queueName, CancellationToken cancellationToken, params Message[] messages);
+        Task<MessagesEnqueued> PostMessagesAsync(QueueName queueName, CancellationToken cancellationToken, params Message[] messages);
 
         /// <summary>
         /// Posts messages to a queue.
@@ -365,7 +365,7 @@
         /// </exception>
         /// <exception cref="WebException">If the REST request does not return successfully.</exception>
         /// <seealso href="https://wiki.openstack.org/w/index.php?title=Marconi/specs/api/v1#Post_Message.28s.29">Post Message(s) (OpenStack Marconi API v1 Blueprint)</seealso>
-        Task PostMessagesAsync<T>(QueueName queueName, IEnumerable<Message<T>> messages, CancellationToken cancellationToken);
+        Task<MessagesEnqueued> PostMessagesAsync<T>(QueueName queueName, IEnumerable<Message<T>> messages, CancellationToken cancellationToken);
 
         /// <summary>
         /// Posts messages to a queue.
@@ -388,7 +388,7 @@
         /// </exception>
         /// <exception cref="WebException">If the REST request does not return successfully.</exception>
         /// <seealso href="https://wiki.openstack.org/w/index.php?title=Marconi/specs/api/v1#Post_Message.28s.29">Post Message(s) (OpenStack Marconi API v1 Blueprint)</seealso>
-        Task PostMessagesAsync<T>(QueueName queueName, CancellationToken cancellationToken, params Message<T>[] messages);
+        Task<MessagesEnqueued> PostMessagesAsync<T>(QueueName queueName, CancellationToken cancellationToken, params Message<T>[] messages);
 
         /// <summary>
         /// Deletes a message from a queue.

--- a/src/corelib/Providers/Rackspace/CloudQueuesProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudQueuesProvider.cs
@@ -516,7 +516,7 @@
         }
 
         /// <inheritdoc/>
-        public Task PostMessagesAsync(QueueName queueName, CancellationToken cancellationToken, params Message[] messages)
+        public Task<MessagesEnqueued> PostMessagesAsync(QueueName queueName, CancellationToken cancellationToken, params Message[] messages)
         {
             if (queueName == null)
                 throw new ArgumentNullException("queueName");
@@ -526,7 +526,8 @@
                 throw new ArgumentException("messages cannot contain any null values");
 
             if (messages.Length == 0)
-                return QueueExistsAsync(queueName, cancellationToken);
+                return QueueExistsAsync(queueName, cancellationToken)
+                    .ContinueWith(t => new MessagesEnqueued(), cancellationToken);
 
             UriTemplate template = new UriTemplate("/queues/{queue_name}/messages");
 
@@ -539,8 +540,8 @@
             Func<Task<Tuple<IdentityToken, Uri>>, Task<HttpWebRequest>> prepareRequest =
                 PrepareRequestAsyncFunc(HttpMethod.POST, template, parameters, messages);
 
-            Func<Task<HttpWebRequest>, Task<string>> requestResource =
-                GetResponseAsyncFunc(cancellationToken);
+            Func<Task<HttpWebRequest>, Task<MessagesEnqueued>> requestResource =
+                GetResponseAsyncFunc<MessagesEnqueued>(cancellationToken);
 
             return AuthenticateServiceAsync(cancellationToken)
                 .Then(prepareRequest)
@@ -548,7 +549,7 @@
         }
 
         /// <inheritdoc/>
-        public Task PostMessagesAsync<T>(QueueName queueName, IEnumerable<Message<T>> messages, CancellationToken cancellationToken)
+        public Task<MessagesEnqueued> PostMessagesAsync<T>(QueueName queueName, IEnumerable<Message<T>> messages, CancellationToken cancellationToken)
         {
             if (queueName == null)
                 throw new ArgumentNullException("queueName");
@@ -559,7 +560,7 @@
         }
 
         /// <inheritdoc/>
-        public Task PostMessagesAsync<T>(QueueName queueName, CancellationToken cancellationToken, params Message<T>[] messages)
+        public Task<MessagesEnqueued> PostMessagesAsync<T>(QueueName queueName, CancellationToken cancellationToken, params Message<T>[] messages)
         {
             if (queueName == null)
                 throw new ArgumentNullException("queueName");
@@ -569,7 +570,8 @@
                 throw new ArgumentException("messages cannot contain any null values");
 
             if (messages.Length == 0)
-                return QueueExistsAsync(queueName, cancellationToken);
+                return QueueExistsAsync(queueName, cancellationToken)
+                    .ContinueWith(task => new MessagesEnqueued(), cancellationToken);
 
             UriTemplate template = new UriTemplate("/queues/{queue_name}/messages");
 
@@ -582,8 +584,8 @@
             Func<Task<Tuple<IdentityToken, Uri>>, Task<HttpWebRequest>> prepareRequest =
                 PrepareRequestAsyncFunc(HttpMethod.POST, template, parameters, messages);
 
-            Func<Task<HttpWebRequest>, Task<string>> requestResource =
-                GetResponseAsyncFunc(cancellationToken);
+            Func<Task<HttpWebRequest>, Task<MessagesEnqueued>> requestResource =
+                GetResponseAsyncFunc<MessagesEnqueued>(cancellationToken);
 
             return AuthenticateServiceAsync(cancellationToken)
                 .Then(prepareRequest)

--- a/src/corelib/corelib.v4.0.csproj
+++ b/src/corelib/corelib.v4.0.csproj
@@ -90,10 +90,12 @@
     <Compile Include="Core\Domain\Queues\CloudQueue.cs" />
     <Compile Include="Core\Domain\Queues\Message.cs" />
     <Compile Include="Core\Domain\Queues\MessageId.cs" />
+    <Compile Include="Core\Domain\Queues\MessagesEnqueued.cs" />
     <Compile Include="Core\Domain\Queues\MessageStatistics.cs" />
     <Compile Include="Core\Domain\Queues\Message`1.cs" />
     <Compile Include="Core\Domain\Queues\NamespaceDoc.cs" />
     <Compile Include="Core\Domain\Queues\QueuedMessage.cs" />
+    <Compile Include="Core\Domain\Queues\QueuedMessageBase.cs" />
     <Compile Include="Core\Domain\Queues\QueuedMessageList.cs" />
     <Compile Include="Core\Domain\Queues\QueuedMessageListId.cs" />
     <Compile Include="Core\Domain\Queues\QueueMessagesStatistics.cs" />


### PR DESCRIPTION
When you post messages to the queue service, the response contains the resource URIs of any successfully enqueued messages. It's useful to have these for further processing/ checks.
