### PR TITLE
Docs style

### DIFF
--- a/src/Documentation/Documentation.v3.5.shfbproj
+++ b/src/Documentation/Documentation.v3.5.shfbproj
@@ -32,7 +32,7 @@
     <SyntaxFilters>Standard</SyntaxFilters>
     <SdkLinkTarget>Blank</SdkLinkTarget>
     <RootNamespaceContainer>True</RootNamespaceContainer>
-    <PresentationStyle>VS2013</PresentationStyle>
+    <PresentationStyle>VS2013Alt</PresentationStyle>
     <Preliminary>False</Preliminary>
     <NamingMethod>MemberName</NamingMethod>
     <HelpTitle>openstack.net API Reference Documentation</HelpTitle>

--- a/src/Documentation/Documentation.v4.0.shfbproj
+++ b/src/Documentation/Documentation.v4.0.shfbproj
@@ -32,7 +32,7 @@
     <SyntaxFilters>Standard</SyntaxFilters>
     <SdkLinkTarget>Blank</SdkLinkTarget>
     <RootNamespaceContainer>True</RootNamespaceContainer>
-    <PresentationStyle>VS2013</PresentationStyle>
+    <PresentationStyle>VS2013Alt</PresentationStyle>
     <Preliminary>False</Preliminary>
     <NamingMethod>MemberName</NamingMethod>
     <HelpTitle>openstack.net API Reference Documentation</HelpTitle>


### PR DESCRIPTION
- Only build Website documentation (reduces documentation build time)
- The `VS2013` presentation style was renamed to `VS2013Alt`; updated documentation projects to match
