### PR TITLE
Fix NuGet dependency for Json.NET

### DIFF
--- a/src/corelib/corelib.nuspec
+++ b/src/corelib/corelib.nuspec
@@ -17,7 +17,7 @@
       <group targetFramework="4.0">
         <!-- Version 1.3.0.1 introduced strong naming for SimpleRESTServices 1.3.x -->
         <dependency id="SimpleRESTServices" version="[1.3.0.1, 1.4)" />
-        <dependency id="Newtonsoft.Json" version="5.0.6" />
+        <dependency id="Newtonsoft.Json" version="[5.0.6, 6.0)" />
       </group>
       <group targetFramework="3.5">
         <!-- Version 1.3.0.1 introduced strong naming for SimpleRESTServices 1.3.x -->


### PR DESCRIPTION
Use more specific version restriction for Json.NET in the NuGet package specification. Previously the .NET 3.5 dependency was updated; this commit updates the .NET 4.0 dependency declaration to match.
