### PR TITLE
Support the Object Storage Service If-None-Match header

### DIFF
--- a/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudFilesProvider.cs
@@ -2389,6 +2389,20 @@ namespace net.openstack.Providers.Rackspace
         public const string Destination = "destination";
 
         /// <summary>
+        /// The <strong>If-None-Match</strong> header, which allows calls to create or update objects to
+        /// query whether the server already has a copy of the object before any data is sent.
+        /// </summary>
+        /// <remarks>
+        /// Currently the service only supports specifying the header <c>If-None-Match: *</c>, which
+        /// results in a <seealso cref="HttpStatusCode.PreconditionFailed"/> response if the Object
+        /// Storage Service contains any file matching the name of the object being updated. Neither
+        /// the content of the object nor its associated metadata are checked by the service.
+        /// </remarks>
+        /// <seealso href="http://docs.openstack.org/api/openstack-object-storage/1.0/content/PUT_createOrReplaceObject__v1__account___container___object__storage_object_services.html">Create or replace object (OpenStack Object Storage API v1 Reference)</seealso>
+        /// <preliminary/>
+        public const string IfNoneMatch = "if-none-match";
+
+        /// <summary>
         /// The <strong>X-Object-Manifest</strong> header, which specifies the container and prefix for the segments of a
         /// dynamic large object.
         /// </summary>

--- a/src/corelib/Providers/Rackspace/ExtendedJsonRestServices.cs
+++ b/src/corelib/Providers/Rackspace/ExtendedJsonRestServices.cs
@@ -1,0 +1,70 @@
+﻿namespace net.openstack.Providers.Rackspace
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using JSIStudios.SimpleRESTServices.Client;
+    using JSIStudios.SimpleRESTServices.Client.Json;
+
+    /// <summary>
+    /// This class extends <see cref="JsonRestServices"/> to add support for handling response
+    /// codes other than <see cref="HttpStatusCode.Continue"/> in response to an
+    /// <c>Expect: 100-Continue</c>.
+    /// </summary>
+    /// <threadsafety static="true" instance="false"/>
+    /// <preliminary/>
+    public class ExtendedJsonRestServices : JsonRestServices
+    {
+        /// <inheritdoc/>
+        /// <remarks>
+        /// This method expands on the base implementation by avoiding writing to the request stream
+        /// if <see cref="HttpWebRequest.HaveResponse"/> is <see langword="true"/>, which prevents
+        /// the requirement that data be sent in the case where sending the <c>Expect: 100-Continue</c>
+        /// header resulted in an immediate error response with first send a
+        /// <see cref="HttpStatusCode.Continue"/>.
+        /// </remarks>
+        public override Response Stream(Uri url, HttpMethod method, Func<HttpWebResponse, bool, Response> responseBuilderCallback, Stream content, int bufferSize, long maxReadLength, Dictionary<string, string> headers, Dictionary<string, string> queryStringParameters, RequestSettings settings, Action<long> progressUpdated)
+        {
+            if (url == null)
+                throw new ArgumentNullException("url");
+            if (content == null)
+                throw new ArgumentNullException("content");
+            if (bufferSize <= 0)
+                throw new ArgumentOutOfRangeException("bufferSize");
+            if (maxReadLength < 0)
+                throw new ArgumentOutOfRangeException("maxReadLength");
+
+            return ExecuteRequest(url, method, responseBuilderCallback, headers, queryStringParameters, settings, (req) =>
+            {
+                long bytesWritten = 0;
+
+                if (settings.ChunkRequest || maxReadLength > 0)
+                {
+                    req.SendChunked = settings.ChunkRequest;
+                    req.AllowWriteStreamBuffering = false;
+                    req.ContentLength = maxReadLength > 0 && content.Length > maxReadLength ? maxReadLength : content.Length;
+                }
+
+                using (Stream stream = req.GetRequestStream())
+                {
+                    var buffer = new byte[bufferSize];
+                    int count;
+                    while (!req.HaveResponse && (count = content.Read(buffer, 0, maxReadLength > 0 ? (int)Math.Min(bufferSize, maxReadLength - bytesWritten) : bufferSize)) > 0)
+                    {
+                        bytesWritten += count;
+                        stream.Write(buffer, 0, count);
+
+                        if (progressUpdated != null)
+                            progressUpdated(bytesWritten);
+
+                        if (maxReadLength > 0 && bytesWritten >= maxReadLength)
+                            break;
+                    }
+                }
+
+                return "[STREAM CONTENT]";
+            });
+        }
+    }
+}

--- a/src/corelib/Providers/Rackspace/ProviderBase`1.cs
+++ b/src/corelib/Providers/Rackspace/ProviderBase`1.cs
@@ -74,7 +74,7 @@ namespace net.openstack.Providers.Rackspace
         /// <param name="defaultIdentity">The default identity to use for calls that do not explicitly specify an identity. If this value is <see langword="null"/>, no default identity is available so all calls must specify an explicit identity.</param>
         /// <param name="defaultRegion">The default region to use for calls that do not explicitly specify a region. If this value is <see langword="null"/>, the default region for the user will be used; otherwise if the service uses region-specific endpoints all calls must specify an explicit region.</param>
         /// <param name="identityProvider">The identity provider to use for authenticating requests to this provider. If this value is <see langword="null"/>, a new instance of <see cref="CloudIdentityProvider"/> is created using <paramref name="defaultIdentity"/> as the default identity.</param>
-        /// <param name="restService">The implementation of <see cref="IRestService"/> to use for executing REST requests. If this value is <see langword="null"/>, the provider will use a new instance of <see cref="JsonRestServices"/>.</param>
+        /// <param name="restService">The implementation of <see cref="IRestService"/> to use for executing REST requests. If this value is <see langword="null"/>, the provider will use a new instance of <see cref="ExtendedJsonRestServices"/>.</param>
         protected ProviderBase(CloudIdentity defaultIdentity, string defaultRegion, IIdentityProvider identityProvider, IRestService restService)
             : this(defaultIdentity, defaultRegion, identityProvider, restService, null) { }
 
@@ -85,14 +85,14 @@ namespace net.openstack.Providers.Rackspace
         /// <param name="defaultIdentity">The default identity to use for calls that do not explicitly specify an identity. If this value is <see langword="null"/>, no default identity is available so all calls must specify an explicit identity.</param>
         /// <param name="defaultRegion">The default region to use for calls that do not explicitly specify a region. If this value is <see langword="null"/>, the default region for the user will be used; otherwise if the service uses region-specific endpoints all calls must specify an explicit region.</param>
         /// <param name="identityProvider">The identity provider to use for authenticating requests to this provider. If this value is <see langword="null"/>, a new instance of <see cref="CloudIdentityProvider"/> is created using <paramref name="defaultIdentity"/> as the default identity.</param>
-        /// <param name="restService">The implementation of <see cref="IRestService"/> to use for executing REST requests. If this value is <see langword="null"/>, the provider will use a new instance of <see cref="JsonRestServices"/>.</param>
+        /// <param name="restService">The implementation of <see cref="IRestService"/> to use for executing REST requests. If this value is <see langword="null"/>, the provider will use a new instance of <see cref="ExtendedJsonRestServices"/>.</param>
         /// <param name="httpStatusCodeValidator">The HTTP status code validator to use. If this value is <see langword="null"/>, the provider will use <see cref="HttpResponseCodeValidator.Default"/>.</param>
         protected ProviderBase(CloudIdentity defaultIdentity, string defaultRegion,  IIdentityProvider identityProvider, IRestService restService, IHttpResponseCodeValidator httpStatusCodeValidator)
         {
             DefaultIdentity = defaultIdentity;
             _defaultRegion = defaultRegion;
             IdentityProvider = identityProvider ?? this as IIdentityProvider ?? new CloudIdentityProvider(defaultIdentity);
-            RestService = restService ?? new JsonRestServices();
+            RestService = restService ?? new ExtendedJsonRestServices();
             ResponseCodeValidator = httpStatusCodeValidator ?? HttpResponseCodeValidator.Default;
         }
 
@@ -625,7 +625,7 @@ namespace net.openstack.Providers.Rackspace
 
             return new JsonRequestSettings
             {
-                RetryCount = 2,
+                RetryCount = 0,
                 RetryDelay = TimeSpan.FromMilliseconds(200),
                 Non200SuccessCodes = non200SuccessCodesAggregate,
                 UserAgent = UserAgentGenerator.UserAgent,

--- a/src/corelib/corelib.v3.5.csproj
+++ b/src/corelib/corelib.v3.5.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Core\Exceptions\NoDefaultRegionSetException.cs" />
     <Compile Include="Core\Exceptions\ServerEnteredErrorStateException.cs" />
     <Compile Include="Providers\Rackspace\Exceptions\NamespaceDoc.cs" />
+    <Compile Include="Providers\Rackspace\ExtendedJsonRestServices.cs" />
     <Compile Include="Providers\Rackspace\IAutoScaleService.cs" />
     <Compile Include="Providers\Rackspace\IDatabaseService.cs" />
     <Compile Include="Providers\Rackspace\IDnsService.cs" />

--- a/src/corelib/corelib.v4.0.csproj
+++ b/src/corelib/corelib.v4.0.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Core\Exceptions\NoDefaultRegionSetException.cs" />
     <Compile Include="Core\Exceptions\ServerEnteredErrorStateException.cs" />
     <Compile Include="Providers\Rackspace\Exceptions\NamespaceDoc.cs" />
+    <Compile Include="Providers\Rackspace\ExtendedJsonRestServices.cs" />
     <Compile Include="Providers\Rackspace\IAutoScaleService.cs" />
     <Compile Include="Providers\Rackspace\IDatabaseService.cs" />
     <Compile Include="Providers\Rackspace\IDnsService.cs" />


### PR DESCRIPTION
- Change the default number of automatic retries in the event of an error status to 0. This improves the performance of many calls which use 400+ status codes for some expected ("success") cases. This does not change the retry behavior in response to an authentication failure.
- Fixes #402
