### PR TITLE
Mark UserQueuesTestsSynchronous as obsolete

### DIFF
--- a/src/testing/integration/Providers/Rackspace/UserQueuesTestsSynchronous.cs
+++ b/src/testing/integration/Providers/Rackspace/UserQueuesTestsSynchronous.cs
@@ -18,6 +18,7 @@
     using Thread = System.Threading.Thread;
 
     /// <preliminary/>
+    [Obsolete]
     [TestClass]
     public class UserQueuesTestsSynchronous
     {


### PR DESCRIPTION
This change fixes build warnings in the test project which were introduced by #412
