### PR TITLE
Remove dependency ranges from NuGet package specification

### DIFF
--- a/src/corelib/corelib.nuspec
+++ b/src/corelib/corelib.nuspec
@@ -16,13 +16,13 @@
     <dependencies>
       <group targetFramework="4.0">
         <!-- Version 1.3.0.1 introduced strong naming for SimpleRESTServices 1.3.x -->
-        <dependency id="SimpleRESTServices" version="[1.3.0.1, 1.4)" />
-        <dependency id="Newtonsoft.Json" version="[5.0.8, 6.0)" />
+        <dependency id="SimpleRESTServices" version="1.3.0.1" />
+        <dependency id="Newtonsoft.Json" version="5.0.8" />
       </group>
       <group targetFramework="3.5">
         <!-- Version 1.3.0.1 introduced strong naming for SimpleRESTServices 1.3.x -->
-        <dependency id="SimpleRESTServices" version="[1.3.0.1, 1.4)" />
-        <dependency id="Newtonsoft.Json" version="[5.0.8, 6.0)" />
+        <dependency id="SimpleRESTServices" version="1.3.0.1" />
+        <dependency id="Newtonsoft.Json" version="5.0.8" />
         <dependency id="TaskParallelLibrary" version="1.0.2856.0" />
       </group>
     </dependencies>


### PR DESCRIPTION
Fixes #433

Currently the NuGet package specification is written with dependency ranges of the form `[5.0.8,6.0)`. While this range is the correct range for users that are not using assembly binding redirection, including the upper limit fully prevents users from installing higher versions and using assembly binding redirection to resolve conflicts.

By changing the version back to the form `5.0.8` (which is equivalent to `[5.0.8,)`), users of the library are responsible for choosing the correct version of the underlying dependency, and for including assembly binding redirection. This change fixes #433 without breaking existing code for users referencing Json.NET 5.x.

Note that **SimpleRESTServices** includes a transitive dependency on Json.NET 5.x, but no upper bound is specified in that dependency so no changes were required in that library to implement this functionality.

This change exposes certain usability issues to end users, including the NuGet Package Manager offering to upgrade the Json.NET dependency of a project in a way that users might not want (e.g. if they don't want to use assembly binding redirection then they won't want to install Json.NET 6.x). However, it seems that managing these issues should not be the responsibility of this project, especially when it causes clear compatibility issues like those mentioned in issue #433. To improve end-user experience, I have reported issue JamesNK/Newtonsoft.Json#417, and also observed that [NuGet issue 2331](https://nuget.codeplex.com/workitem/2331) aims to improve the user experience from that side.
