### PR TITLE
Add Cloud Identity examples

### DIFF
--- a/src/Samples/CPPCodeSamples/CPPCodeSamples.vcxproj
+++ b/src/Samples/CPPCodeSamples/CPPCodeSamples.vcxproj
@@ -74,6 +74,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.5.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="SimpleRESTServices">
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -85,6 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
+    <ClCompile Include="IdentityProviderExamples.cpp" />
     <ClCompile Include="ObjectStorageProviderExamples.cpp" />
     <ClCompile Include="QueueingServiceExamples.cpp" />
     <ClCompile Include="Stdafx.cpp">

--- a/src/Samples/CPPCodeSamples/CPPCodeSamples.vcxproj.filters
+++ b/src/Samples/CPPCodeSamples/CPPCodeSamples.vcxproj.filters
@@ -35,6 +35,9 @@
     <ClCompile Include="ObjectStorageProviderExamples.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="IdentityProviderExamples.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Text Include="ReadMe.txt" />

--- a/src/Samples/CPPCodeSamples/IdentityProviderExamples.cpp
+++ b/src/Samples/CPPCodeSamples/IdentityProviderExamples.cpp
@@ -1,0 +1,136 @@
+#include "Stdafx.h"
+
+using namespace net::openstack::Core::Domain;
+using namespace net::openstack::Providers::Rackspace;
+using namespace System;
+
+ref class IdentityProviderExamples
+{
+public:
+	void CreateProvider()
+	{
+#pragma region CreateProvider
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+#pragma endregion
+	}
+
+	void CreateProviderWithPassword()
+	{
+#pragma region CreateProviderWithPassword
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->Password = "{password}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+#pragma endregion
+	}
+
+	void CreateUser()
+	{
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+
+#pragma region CreateUser
+		auto user = gcnew NewUser("{username}", "{email}", nullptr, true);
+		user = provider->AddUser(user, nullptr);
+		auto password = user->Password;
+#pragma endregion
+	}
+
+	void UpdateUser()
+	{
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+
+#pragma region UpdateUser
+		auto user = provider->GetUserByName("{username}", nullptr);
+		user->Username = "{newUsername}";
+		provider->UpdateUser(user, nullptr);
+#pragma endregion
+	}
+
+	void ListUsers()
+	{
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+
+#pragma region ListUsers
+		auto users = provider->ListUsers(nullptr);
+		for each (User^ user in users)
+			Console::WriteLine("{0}: {1}", user->Id, user->Username);
+#pragma endregion
+	}
+
+	void AddRoleToUser()
+	{
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+
+#pragma region AddRoleToUser
+		auto user = provider->GetUserByName("{username}", nullptr);
+		provider->AddRoleToUser(user->Id, "{roleId}", nullptr);
+#pragma endregion
+	}
+
+	void DeleteRoleFromUser()
+	{
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+
+#pragma region DeleteRoleFromUser
+		auto user = provider->GetUserByName("{username}", nullptr);
+		provider->DeleteRoleFromUser(user->Id, "{roleId}", nullptr);
+#pragma endregion
+	}
+
+	void ResetApiKey()
+	{
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+
+#pragma region ResetApiKey
+		auto credential = provider->ResetApiKey("{userId}", nullptr);
+		auto newApiKey = credential->APIKey;
+#pragma endregion
+	}
+
+	void ListRoles()
+	{
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+
+#pragma region ListRoles
+		auto roles = provider->ListRoles(nullptr, Nullable<int>(), Nullable<int>(), nullptr);
+		for each (Role^ role in roles)
+			Console::WriteLine("{0}: {1}", role->Id, role->Name);
+#pragma endregion
+	}
+
+	void DeleteUser()
+	{
+		auto identity = gcnew CloudIdentity();
+		identity->Username = "{username}";
+		identity->APIKey = "{apiKey}";
+		auto provider = gcnew CloudIdentityProvider(identity);
+
+#pragma region DeleteUser
+		provider->DeleteUser("{userId}", nullptr);
+#pragma endregion
+	}
+};

--- a/src/Samples/CSharpCodeSamples/CSharpCodeSamples.csproj
+++ b/src/Samples/CSharpCodeSamples/CSharpCodeSamples.csproj
@@ -34,8 +34,15 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Rackspace.Threading">
       <HintPath>..\..\packages\Rackspace.Threading.1.1.0-beta001\lib\net45\Rackspace.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleRESTServices, Version=1.3.0.0, Culture=neutral, PublicKeyToken=8965cea5c205d3a3, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsynchronousExceptionsExamples.cs" />
+    <Compile Include="IdentityProviderExamples.cs" />
     <Compile Include="ObjectStorageProviderExamples.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QueueingServiceExamples.cs" />

--- a/src/Samples/CSharpCodeSamples/IdentityProviderExamples.cs
+++ b/src/Samples/CSharpCodeSamples/IdentityProviderExamples.cs
@@ -1,0 +1,117 @@
+﻿namespace CSharpCodeSamples
+{
+    using System;
+    using System.Collections.Generic;
+    using net.openstack.Core.Domain;
+    using net.openstack.Providers.Rackspace;
+
+    public class IdentityProviderExamples
+    {
+        public void CreateProvider()
+        {
+            #region CreateProvider
+            var identity = new CloudIdentity { Username = "{username}", APIKey = "{apiKey}" };
+            var provider = new CloudIdentityProvider(identity);
+            #endregion
+        }
+
+        public void CreateProviderWithPassword()
+        {
+            #region CreateProviderWithPassword
+            var identity = new CloudIdentity { Username = "{username}", Password = "{password}" };
+            var provider = new CloudIdentityProvider(identity);
+            #endregion
+        }
+
+        public void CreateUser()
+        {
+            var identity = new CloudIdentity();
+            var provider = new CloudIdentityProvider(identity);
+
+            #region CreateUser
+            NewUser user = new NewUser("{username}", "{email}", enabled: true);
+            user = provider.AddUser(user, null);
+            string password = user.Password;
+            #endregion
+        }
+
+        public void UpdateUser()
+        {
+            var identity = new CloudIdentity { Username = "{username}", APIKey = "{apiKey}" };
+            var provider = new CloudIdentityProvider(identity);
+
+            #region UpdateUser
+            User user = provider.GetUserByName("{username}", null);
+            user.Username = "{newUsername}";
+            provider.UpdateUser(user, null);
+            #endregion
+        }
+
+        public void ListUsers()
+        {
+            var identity = new CloudIdentity { Username = "{username}", APIKey = "{apiKey}" };
+            var provider = new CloudIdentityProvider(identity);
+
+            #region ListUsers
+            IEnumerable<User> users = provider.ListUsers(null);
+            foreach (var user in users)
+                Console.WriteLine("{0}: {1}", user.Id, user.Username);
+            #endregion
+        }
+
+        public void AddRoleToUser()
+        {
+            var identity = new CloudIdentity { Username = "{username}", APIKey = "{apiKey}" };
+            var provider = new CloudIdentityProvider(identity);
+
+            #region AddRoleToUser
+            User user = provider.GetUserByName("{username}", null);
+            provider.AddRoleToUser(user.Id, "{roleId}", null);
+            #endregion
+        }
+
+        public void DeleteRoleFromUser()
+        {
+            var identity = new CloudIdentity { Username = "{username}", APIKey = "{apiKey}" };
+            var provider = new CloudIdentityProvider(identity);
+
+            #region DeleteRoleFromUser
+            User user = provider.GetUserByName("{username}", null);
+            provider.DeleteRoleFromUser(user.Id, "{roleId}", null);
+            #endregion
+        }
+
+        public void ResetApiKey()
+        {
+            var identity = new CloudIdentity { Username = "{username}", APIKey = "{apiKey}" };
+            var provider = new CloudIdentityProvider(identity);
+
+            #region ResetApiKey
+            UserCredential credential = provider.ResetApiKey("{userId}");
+            string newApiKey = credential.APIKey;
+            #endregion
+        }
+
+        public void ListRoles()
+        {
+            var identity = new CloudIdentity { Username = "{username}", APIKey = "{apiKey}" };
+            var provider = new CloudIdentityProvider(identity);
+
+            #region ListRoles
+            IEnumerable<Role> roles = provider.ListRoles();
+            foreach (var role in roles)
+                Console.WriteLine("{0}: {1}", role.Id, role.Name);
+            #endregion
+        }
+
+        public void DeleteUser()
+        {
+            var identity = new CloudIdentity { Username = "{username}", APIKey = "{apiKey}" };
+            var provider = new CloudIdentityProvider(identity);
+
+            #region DeleteUser
+            provider.DeleteUser("{userId}", null);
+            #endregion
+        }
+    }
+}

--- a/src/Samples/CSharpCodeSamples/packages.CSharpCodeSamples.config
+++ b/src/Samples/CSharpCodeSamples/packages.CSharpCodeSamples.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="Rackspace.Threading" version="1.1.0-beta001" targetFramework="net45" />
+  <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net45" />
 </packages>

--- a/src/Samples/FSharpCodeSamples/FSharpCodeSamples.fsproj
+++ b/src/Samples/FSharpCodeSamples/FSharpCodeSamples.fsproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>FSharpCodeSamples</Name>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,6 +38,14 @@
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SimpleRESTServices">
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -54,6 +63,8 @@
   <ItemGroup>
     <Compile Include="QueueingServiceExamples.fs" />
     <Compile Include="ObjectStorageProviderExamples.fs" />
+    <Compile Include="IdentityProviderExamples.fs" />
+    <Content Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0'">

--- a/src/Samples/FSharpCodeSamples/IdentityProviderExamples.fs
+++ b/src/Samples/FSharpCodeSamples/IdentityProviderExamples.fs
@@ -1,0 +1,94 @@
+﻿module IdentityProviderExamples
+
+open System
+open net.openstack.Core.Domain
+open net.openstack.Providers.Rackspace
+
+let createProvider =
+    //#region CreateProvider
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#endregion
+    ()
+
+let createProviderWithPassword =
+    //#region CreateProviderWithPassword
+    let identity = new CloudIdentity (Username = "{username}", Password = "{password}")
+    let provider = new CloudIdentityProvider(identity)
+    //#endregion
+    ()
+
+let createUser =
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#region CreateUser
+    let user = new NewUser("{username}", "{email}", enabled=true)
+    let user = provider.AddUser(user, null)
+    let password = user.Password
+    //#endregion
+    ()
+
+let updateUser =
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#region UpdateUser
+    let user = provider.GetUserByName("{username}", null)
+    user.Username <- "{newUsername}"
+    provider.UpdateUser(user, null) |> ignore
+    //#endregion
+    ()
+
+let listUsers =
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#region ListUsers
+    let users = provider.ListUsers(null)
+    for user in users do
+        Console.WriteLine("{0}: {1}", user.Id, user.Username)
+    //#endregion
+    ()
+
+let addRoleToUser =
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#region AddRoleToUser
+    let user = provider.GetUserByName("{username}", null)
+    provider.AddRoleToUser(user.Id, "{roleId}", null) |> ignore
+    //#endregion
+    ()
+
+let deleteRoleFromUser =
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#region DeleteRoleFromUser
+    let user = provider.GetUserByName("{username}", null)
+    provider.DeleteRoleFromUser(user.Id, "{roleId}", null) |> ignore
+    //#endregion
+    ()
+
+let resetApiKey =
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#region ResetApiKey
+    let credential = provider.ResetApiKey("{userId}")
+    let newApiKey = credential.APIKey
+    //#endregion
+    ()
+
+let listRoles =
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#region ListRoles
+    let roles = provider.ListRoles()
+    for role in roles do
+        Console.WriteLine("{0}: {1}", role.Id, role.Name)
+    //#endregion
+    ()
+
+let deleteUser =
+    let identity = new CloudIdentity (Username = "{username}", APIKey = "{apiKey}")
+    let provider = new CloudIdentityProvider(identity)
+    //#region DeleteUser
+    provider.DeleteUser("{userId}", null) |> ignore
+    //#endregion
+    ()

--- a/src/Samples/FSharpCodeSamples/packages.config
+++ b/src/Samples/FSharpCodeSamples/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net40" />
+  <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net40" />
+</packages>

--- a/src/Samples/VBCodeSamples/IdentityProviderExamples.vb
+++ b/src/Samples/VBCodeSamples/IdentityProviderExamples.vb
@@ -1,0 +1,105 @@
+﻿Imports net.openstack.Core.Domain
+Imports net.openstack.Providers.Rackspace
+
+Public Class IdentityProviderExamples
+
+    Public Sub CreateProvider()
+        ' #Region "CreateProvider"
+        Dim identity = New CloudIdentity With {.Username = "{username}", .APIKey = "{apiKey}"}
+        Dim provider = New CloudIdentityProvider(identity)
+        ' #End Region
+    End Sub
+
+    Public Sub CreateProviderWithPassword()
+        ' #Region "CreateProviderWithPassword"
+        Dim identity = New CloudIdentity With {.Username = "{username}", .Password = "{password}"}
+        Dim provider = New CloudIdentityProvider(identity)
+        ' #End Region
+    End Sub
+
+    Public Sub CreateUser()
+        Dim identity = New CloudIdentity
+        Dim provider = New CloudIdentityProvider(identity)
+
+        ' #Region "CreateUser"
+        Dim User = New NewUser("{username}", "{email}", enabled:=True)
+        User = provider.AddUser(User, Nothing)
+        Dim password = User.Password
+        ' #End Region
+    End Sub
+
+    Public Sub UpdateUser()
+        Dim identity = New CloudIdentity
+        Dim provider = New CloudIdentityProvider(identity)
+
+        ' #Region "UpdateUser"
+        Dim user = provider.GetUserByName("{username}", Nothing)
+        user.Username = "{newUsername}"
+        provider.UpdateUser(user, Nothing)
+        ' #End Region
+    End Sub
+
+    Public Sub ListUsers()
+        Dim identity = New CloudIdentity
+        Dim provider = New CloudIdentityProvider(identity)
+
+        ' #Region "ListUsers"
+        Dim users = provider.ListUsers(Nothing)
+        For Each user As User In users
+            Console.WriteLine("{0}: {1}", user.Id, user.Username)
+        Next
+        ' #End Region
+    End Sub
+
+    Public Sub AddRoleToUser()
+        Dim identity = New CloudIdentity
+        Dim provider = New CloudIdentityProvider(identity)
+
+        ' #Region "AddRoleToUser"
+        Dim user = provider.GetUserByName("{username}", Nothing)
+        provider.AddRoleToUser(user.Id, "{roleId}", Nothing)
+        ' #End Region
+    End Sub
+
+    Public Sub DeleteRoleFromUser()
+        Dim identity = New CloudIdentity
+        Dim provider = New CloudIdentityProvider(identity)
+
+        ' #Region "DeleteRoleFromUser"
+        Dim user = provider.GetUserByName("{username}", Nothing)
+        provider.DeleteRoleFromUser(user.Id, "{roleId}", Nothing)
+        ' #End Region
+    End Sub
+
+    Public Sub ResetApiKey()
+        Dim identity = New CloudIdentity
+        Dim provider = New CloudIdentityProvider(identity)
+
+        ' #Region "ResetApiKey"
+        Dim credential = provider.ResetApiKey("{userId}")
+        Dim newApiKey As String = credential.APIKey
+        ' #End Region
+    End Sub
+
+    Public Sub ListRoles()
+        Dim identity = New CloudIdentity
+        Dim provider = New CloudIdentityProvider(identity)
+
+        ' #Region "ListRoles"
+        Dim roles = provider.ListRoles
+        For Each role As Role In roles
+            Console.WriteLine("{0}: {1}", role.Id, role.Name)
+        Next
+        ' #End Region
+    End Sub
+
+    Public Sub DeleteUser()
+        Dim identity = New CloudIdentity
+        Dim provider = New CloudIdentityProvider(identity)
+
+        ' #Region "DeleteUser"
+        provider.DeleteUser("{userId}", Nothing)
+        ' #End Region
+    End Sub
+
+End Class

--- a/src/Samples/VBCodeSamples/VBCodeSamples.vbproj
+++ b/src/Samples/VBCodeSamples/VBCodeSamples.vbproj
@@ -47,8 +47,15 @@
     <OptionInfer>On</OptionInfer>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Rackspace.Threading">
       <HintPath>..\..\packages\Rackspace.Threading.1.1.0-beta001\lib\net45\Rackspace.Threading.dll</HintPath>
+    </Reference>
+    <Reference Include="SimpleRESTServices, Version=1.3.0.0, Culture=neutral, PublicKeyToken=8965cea5c205d3a3, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -69,6 +76,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsynchronousExceptionsExamples.vb" />
+    <Compile Include="IdentityProviderExamples.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>

--- a/src/Samples/VBCodeSamples/packages.VBCodeSamples.config
+++ b/src/Samples/VBCodeSamples/packages.VBCodeSamples.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="Rackspace.Threading" version="1.1.0-beta001" targetFramework="net45" />
+  <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net45" />
 </packages>

--- a/src/corelib/Core/Providers/IIdentityProvider.cs
+++ b/src/corelib/Core/Providers/IIdentityProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using net.openstack.Core.Domain;
 using net.openstack.Core.Exceptions.Response;
+using net.openstack.Providers.Rackspace;
 
 namespace net.openstack.Core.Providers
 {
@@ -89,6 +90,15 @@ namespace net.openstack.Core.Providers
         /// </exception>
         /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <see langword="null"/> and no default identity is available for the provider.</exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method using the <see cref="CloudIdentityProvider"/>
+        /// implementation of <see cref="IIdentityProvider"/>. For more information about creating the provider, see
+        /// <see cref="CloudIdentityProvider(CloudIdentity)"/>.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="ListUsers" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="ListUsers" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="ListUsers" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="ListUsers" language="fs"/>
+        /// </example>
         /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/GET_listUsers_v2.0_users_.html">List Users (OpenStack Identity Service API v2.0 Reference)</seealso>
         IEnumerable<User> ListUsers(CloudIdentity identity = null);
 
@@ -150,6 +160,15 @@ namespace net.openstack.Core.Providers
         /// </exception>
         /// <exception cref="ServiceConflictException">If a user with the specified <see cref="NewUser.Username"/> already exists.</exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method using the <see cref="CloudIdentityProvider"/>
+        /// implementation of <see cref="IIdentityProvider"/>. For more information about creating the provider, see
+        /// <see cref="CloudIdentityProvider(CloudIdentity)"/>.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="CreateUser" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="CreateUser" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="CreateUser" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="CreateUser" language="fs"/>
+        /// </example>
         /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/POST_addUser_v2.0_users_.html">Add User (OpenStack Identity Service API v2.0 Reference)</seealso>
         NewUser AddUser(NewUser user, CloudIdentity identity = null);
 
@@ -174,6 +193,15 @@ namespace net.openstack.Core.Providers
         /// </exception>
         /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <see langword="null"/> and no default identity is available for the provider.</exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method using the <see cref="CloudIdentityProvider"/>
+        /// implementation of <see cref="IIdentityProvider"/>. For more information about creating the provider, see
+        /// <see cref="CloudIdentityProvider(CloudIdentity)"/>.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="UpdateUser" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="UpdateUser" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="UpdateUser" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="UpdateUser" language="fs"/>
+        /// </example>
         /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/POST_updateUser_v2.0_users__userId__.html">Update User (OpenStack Identity Service API v2.0 Reference)</seealso>
         User UpdateUser(User user, CloudIdentity identity = null);
 
@@ -192,6 +220,15 @@ namespace net.openstack.Core.Providers
         /// </exception>
         /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <see langword="null"/> and no default identity is available for the provider.</exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method using the <see cref="CloudIdentityProvider"/>
+        /// implementation of <see cref="IIdentityProvider"/>. For more information about creating the provider, see
+        /// <see cref="CloudIdentityProvider(CloudIdentity)"/>.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="DeleteUser" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="DeleteUser" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="DeleteUser" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="DeleteUser" language="fs"/>
+        /// </example>
         /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/DELETE_deleteUser_v2.0_users__userId__.html">Delete User (OpenStack Identity Service API v2.0 Reference)</seealso>
         bool DeleteUser(string userId, CloudIdentity identity = null);
 

--- a/src/corelib/Providers/Rackspace/CloudIdentityProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudIdentityProvider.cs
@@ -53,6 +53,20 @@ namespace net.openstack.Providers.Rackspace
         /// implementation, and token cache.
         /// </summary>
         /// <param name="defaultIdentity">The default identity to use for calls that do not explicitly specify an identity. If this value is <see langword="null"/>, no default identity is available so all calls must specify an explicit identity.</param>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method to create an identity provider that
+        /// authenticates using username and API key credentials.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="CreateProvider" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="CreateProvider" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="CreateProvider" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="CreateProvider" language="fs"/>
+        /// <para>The following example demonstrates the use of this method to create an identity provider that
+        /// authenticates using username and password credentials.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="CreateProviderWithPassword" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="CreateProviderWithPassword" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="CreateProviderWithPassword" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="CreateProviderWithPassword" language="fs"/>
+        /// </example>
         public CloudIdentityProvider(CloudIdentity defaultIdentity)
             : this(defaultIdentity, null, null, null)
         { }
@@ -450,6 +464,14 @@ namespace net.openstack.Providers.Rackspace
         /// </exception>
         /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <see langword="null"/> and no default identity is available for the provider.</exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method. For more information about creating the
+        /// provider, see <see cref="CloudIdentityProvider(CloudIdentity)"/>.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="ResetApiKey" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="ResetApiKey" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="ResetApiKey" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="ResetApiKey" language="fs"/>
+        /// </example>
         /// <seealso href="http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/POST_resetUserAPIKeyCredentials__v2.0_users__userId__OS-KSADM_credentials_RAX-KSKEYapiKeyCredentials_RAX-AUTH_reset_User_Calls.html">Reset API key credentials (Rackspace Cloud Identity Client Developer Guide - API v2.0)</seealso>
         public virtual UserCredential ResetApiKey(string userId, CloudIdentity identity = null)
         {

--- a/src/corelib/Providers/Rackspace/IExtendedCloudIdentityProvider.cs
+++ b/src/corelib/Providers/Rackspace/IExtendedCloudIdentityProvider.cs
@@ -27,6 +27,15 @@ namespace net.openstack.Providers.Rackspace
         /// <exception cref="NotSupportedException">If the provider does not support the given <paramref name="identity"/> type.</exception>
         /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <see langword="null"/> and no default identity is available for the provider.</exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method using the <see cref="CloudIdentityProvider"/>
+        /// implementation of <see cref="IExtendedCloudIdentityProvider"/>. For more information about creating the provider, see
+        /// <see cref="CloudIdentityProvider(CloudIdentity)"/>.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="ListRoles" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="ListRoles" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="ListRoles" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="ListRoles" language="fs"/>
+        /// </example>
         /// <seealso href="http://docs.rackspace.com/openstack-extensions/auth/OS-KSADM-admin-devguide/content/GET_listRoles_v2.0_OS-KSADM_roles_Admin_API_Service_Developer_Operations-d1e1357.html">List Roles (Rackspace OS-KSADM Extension - API v2.0)</seealso>
         IEnumerable<Role> ListRoles(string serviceId = null, int? marker = null, int? limit = null, CloudIdentity identity = null);
 
@@ -106,6 +115,15 @@ namespace net.openstack.Providers.Rackspace
         /// </exception>
         /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <see langword="null"/> and no default identity is available for the provider.</exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method using the <see cref="CloudIdentityProvider"/>
+        /// implementation of <see cref="IExtendedCloudIdentityProvider"/>. For more information about creating the provider, see
+        /// <see cref="CloudIdentityProvider(CloudIdentity)"/>.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="AddRoleToUser" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="AddRoleToUser" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="AddRoleToUser" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="AddRoleToUser" language="fs"/>
+        /// </example>
         /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/PUT_addUserRole_v2.0_users__userId__roles_OS-KSADM__roleId__.html">Add Global Role to User (OpenStack Identity Service API v2.0 Reference)</seealso>
         bool AddRoleToUser(string userId, string roleId, CloudIdentity identity = null);
 
@@ -133,6 +151,15 @@ namespace net.openstack.Providers.Rackspace
         /// </exception>
         /// <exception cref="InvalidOperationException">If <paramref name="identity"/> is <see langword="null"/> and no default identity is available for the provider.</exception>
         /// <exception cref="ResponseException">If the REST API request failed.</exception>
+        /// <example>
+        /// <para>The following example demonstrates the use of this method using the <see cref="CloudIdentityProvider"/>
+        /// implementation of <see cref="IExtendedCloudIdentityProvider"/>. For more information about creating the provider, see
+        /// <see cref="CloudIdentityProvider(CloudIdentity)"/>.</para>
+        /// <code source="..\Samples\CSharpCodeSamples\IdentityProviderExamples.cs" region="DeleteRoleFromUser" language="cs"/>
+        /// <code source="..\Samples\VBCodeSamples\IdentityProviderExamples.vb" region="DeleteRoleFromUser" language="vbnet"/>
+        /// <code source="..\Samples\CPPCodeSamples\IdentityProviderExamples.cpp" region="DeleteRoleFromUser" language="cpp"/>
+        /// <code source="..\Samples\FSharpCodeSamples\IdentityProviderExamples.fs" region="DeleteRoleFromUser" language="fs"/>
+        /// </example>
         /// <seealso href="http://docs.openstack.org/api/openstack-identity-service/2.0/content/DELETE_deleteUserRole_v2.0_users__userId__roles_OS-KSADM__roleId__.html">Delete Global Role from User (OpenStack Identity Service API v2.0 Reference)</seealso>
         bool DeleteRoleFromUser(string userId, string roleId, CloudIdentity identity = null);
 


### PR DESCRIPTION
The examples for each language are created, but the documentation for `IIdentityProvider` and `CloudIdentityProvider` still needs to be updated to reference each of the examples.
