### PR TITLE
JSON Home object model classes extend ExtensibleJsonObject

### DIFF
--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/AuthenticationRequirement.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/AuthenticationRequirement.cs
@@ -12,7 +12,7 @@
     /// <threadsafety static="true" instance="false"/>
     /// <preliminary/>
     [JsonObject(MemberSerialization.OptIn)]
-    public class AuthenticationRequirement
+    public class AuthenticationRequirement : ExtensibleJsonObject
     {
 #pragma warning disable 649 // Field 'fieldName' is never assigned to, and will always have its default value {value}
         /// <summary>

--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/HomeDocument.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/HomeDocument.cs
@@ -11,7 +11,7 @@
     /// <threadsafety static="true" instance="false"/>
     /// <preliminary/>
     [JsonObject(MemberSerialization.OptIn)]
-    public class HomeDocument
+    public class HomeDocument : ExtensibleJsonObject
     {
 #pragma warning disable 649 // Field 'fieldName' is never assigned to, and will always have its default value {value}
         /// <summary>

--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/ResourceHints.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/ResourceHints.cs
@@ -39,7 +39,7 @@
     /// <threadsafety static="true" instance="false"/>
     /// <preliminary/>
     [JsonObject(MemberSerialization.OptIn)]
-    public class ResourceHints
+    public class ResourceHints : ExtensibleJsonObject
     {
 #pragma warning disable 649 // Field 'fieldName' is never assigned to, and will always have its default value {value}
         /// <summary>

--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/ResourceObject.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/ResourceObject.cs
@@ -12,7 +12,7 @@
     /// <threadsafety static="true" instance="false"/>
     /// <preliminary/>
     [JsonObject(MemberSerialization.OptIn)]
-    public class ResourceObject
+    public class ResourceObject : ExtensibleJsonObject
     {
 #pragma warning disable 649 // Field 'fieldName' is never assigned to, and will always have its default value {value}
         /// <summary>


### PR DESCRIPTION
During the initial refactoring for V2, these classes were not updated to extend `ExtensibleJsonObject`. This pull request corrects that.