### PR TITLE
Updated ReadOnlyDictionary<TKey, TValue> to use the code from Microsoft

### DIFF
--- a/src/OpenStack.Net/OpenStack.Net.net35.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net35.csproj
@@ -167,6 +167,7 @@
     <Compile Include="System\Collections\Concurrent\CollectionDebuggerView`2.cs" />
     <Compile Include="System\Collections\Concurrent\ConcurrentDictionary`2.cs" />
     <Compile Include="System\Collections\Concurrent\SplitOrderedList`2.cs" />
+    <Compile Include="System\Collections\Generic\DictionaryDebugView`2.cs" />
     <Compile Include="System\Collections\Generic\OpenStackListExtensions.cs" />
     <Compile Include="System\Collections\IStructuralComparable.cs" />
     <Compile Include="System\Collections\IStructuralEquatable.cs" />

--- a/src/OpenStack.Net/OpenStack.Net.net40.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net40.csproj
@@ -183,6 +183,7 @@
     <Compile Include="System\Collections\Concurrent\CollectionDebuggerView`2.cs" />
     <Compile Include="System\Collections\Concurrent\ConcurrentDictionary`2.cs" />
     <Compile Include="System\Collections\Concurrent\SplitOrderedList`2.cs" />
+    <Compile Include="System\Collections\Generic\DictionaryDebugView`2.cs" />
     <Compile Include="System\Collections\Generic\OpenStackListExtensions.cs" />
     <Compile Include="System\Collections\IStructuralComparable.cs" />
     <Compile Include="System\Collections\IStructuralEquatable.cs" />

--- a/src/OpenStack.Net/OpenStack.Net.net45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net45.csproj
@@ -160,6 +160,7 @@
     <Compile Include="System\Collections\Concurrent\CollectionDebuggerView`2.cs" />
     <Compile Include="System\Collections\Concurrent\ConcurrentDictionary`2.cs" />
     <Compile Include="System\Collections\Concurrent\SplitOrderedList`2.cs" />
+    <Compile Include="System\Collections\Generic\DictionaryDebugView`2.cs" />
     <Compile Include="System\Collections\Generic\OpenStackListExtensions.cs" />
     <Compile Include="System\Collections\IStructuralComparable.cs" />
     <Compile Include="System\Collections\IStructuralEquatable.cs" />

--- a/src/OpenStack.Net/OpenStack.Net.netcore45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.netcore45.csproj
@@ -163,6 +163,7 @@
     <Compile Include="System\Collections\Concurrent\CollectionDebuggerView`2.cs" />
     <Compile Include="System\Collections\Concurrent\ConcurrentDictionary`2.cs" />
     <Compile Include="System\Collections\Concurrent\SplitOrderedList`2.cs" />
+    <Compile Include="System\Collections\Generic\DictionaryDebugView`2.cs" />
     <Compile Include="System\Collections\Generic\OpenStackListExtensions.cs" />
     <Compile Include="System\Collections\IStructuralComparable.cs" />
     <Compile Include="System\Collections\IStructuralEquatable.cs" />

--- a/src/OpenStack.Net/OpenStack.Net.portable-net40.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.portable-net40.csproj
@@ -174,6 +174,7 @@
     <Compile Include="System\Collections\Concurrent\CollectionDebuggerView`2.cs" />
     <Compile Include="System\Collections\Concurrent\ConcurrentDictionary`2.cs" />
     <Compile Include="System\Collections\Concurrent\SplitOrderedList`2.cs" />
+    <Compile Include="System\Collections\Generic\DictionaryDebugView`2.cs" />
     <Compile Include="System\Collections\Generic\OpenStackListExtensions.cs" />
     <Compile Include="System\Collections\IStructuralComparable.cs" />
     <Compile Include="System\Collections\IStructuralEquatable.cs" />

--- a/src/OpenStack.Net/OpenStack.Net.portable-net45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.portable-net45.csproj
@@ -165,6 +165,7 @@
     <Compile Include="System\Collections\Concurrent\CollectionDebuggerView`2.cs" />
     <Compile Include="System\Collections\Concurrent\ConcurrentDictionary`2.cs" />
     <Compile Include="System\Collections\Concurrent\SplitOrderedList`2.cs" />
+    <Compile Include="System\Collections\Generic\DictionaryDebugView`2.cs" />
     <Compile Include="System\Collections\Generic\OpenStackListExtensions.cs" />
     <Compile Include="System\Collections\IStructuralComparable.cs" />
     <Compile Include="System\Collections\IStructuralEquatable.cs" />

--- a/src/OpenStack.Net/System/Collections/Generic/DictionaryDebugView`2.cs
+++ b/src/OpenStack.Net/System/Collections/Generic/DictionaryDebugView`2.cs
@@ -1,0 +1,133 @@
+﻿#if !NET45PLUS
+
+// ==++==
+// 
+//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// 
+// ==--==
+/*=============================================================================
+**
+**
+**
+** Purpose: DebugView class for generic collections
+** 
+** <OWNER>[....]</OWNER>
+**
+**
+=============================================================================*/
+
+namespace System.Collections.Generic {
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Diagnostics;    
+    using System.Diagnostics.Contracts;
+
+    //
+    // VS IDE can't differentiate between types with the same name from different
+    // assembly. So we need to use different names for collection debug view for 
+    // collections in mscorlib.dll and system.dll.
+    //
+    internal sealed class Mscorlib_CollectionDebugView<T> {
+        private ICollection<T> collection; 
+        
+        public Mscorlib_CollectionDebugView(ICollection<T> collection) {
+            if (collection == null)
+                throw new ArgumentNullException("collection");
+
+                this.collection = collection;
+        }
+       
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items   { 
+            get {
+                T[] items = new T[collection.Count];
+                collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }        
+
+    internal sealed class Mscorlib_DictionaryKeyCollectionDebugView<TKey, TValue> {
+        private ICollection<TKey> collection; 
+        
+        public Mscorlib_DictionaryKeyCollectionDebugView(ICollection<TKey> collection) {
+            if (collection == null)
+                throw new ArgumentNullException("collection");
+
+                this.collection = collection;
+        }
+       
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TKey[] Items   { 
+            get {
+                TKey[] items = new TKey[collection.Count];
+                collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }        
+
+    internal sealed class Mscorlib_DictionaryValueCollectionDebugView<TKey, TValue> {
+        private ICollection<TValue> collection; 
+        
+        public Mscorlib_DictionaryValueCollectionDebugView(ICollection<TValue> collection) {
+            if (collection == null)
+                throw new ArgumentNullException("collection");
+
+                this.collection = collection;
+        }
+       
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TValue[] Items   { 
+            get {
+                TValue[] items = new TValue[collection.Count];
+                collection.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }        
+
+    internal sealed class Mscorlib_DictionaryDebugView<K, V> {
+        private IDictionary<K, V> dict; 
+        
+        public Mscorlib_DictionaryDebugView(IDictionary<K, V> dictionary) {
+            if (dictionary == null)
+                throw new ArgumentNullException("dictionary");
+
+                this.dict = dictionary;
+        }
+       
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public KeyValuePair<K, V>[] Items   { 
+            get {
+                KeyValuePair<K, V>[] items = new KeyValuePair<K, V>[dict.Count];
+                dict.CopyTo(items, 0);
+                return items;
+            }
+        }
+    }        
+
+    internal sealed class Mscorlib_KeyedCollectionDebugView<K, T> {
+        private KeyedCollection<K, T> kc; 
+        
+        public Mscorlib_KeyedCollectionDebugView(KeyedCollection<K, T> keyedCollection) {
+            if (keyedCollection == null) {
+                throw new ArgumentNullException("keyedCollection");
+            }
+            Contract.EndContractBlock();
+
+            kc = keyedCollection;
+        }
+       
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public T[] Items   { 
+            get {
+                T[] items = new T[kc.Count];
+                kc.CopyTo(items, 0);
+                return items;
+            }
+        }        
+    }            
+}
+
+#endif


### PR DESCRIPTION
Now that Microsoft has released the Reference Source for `ReadOnlyDictionary<TKey, TValue>`, we can update the code to use this implementation instead of the one from Mono.

This pull request only affects the V2 SDK.