### PR TITLE
Fix incorrect constructor comments

### DIFF
--- a/src/OpenStack.Net/OpenStack/Net/HttpApiCall`1.cs
+++ b/src/OpenStack.Net/OpenStack/Net/HttpApiCall`1.cs
@@ -69,7 +69,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CustomHttpApiCall{T}"/> class with
+        /// Initializes a new instance of the <see cref="HttpApiCall{T}"/> class with
         /// the specified <see cref="HttpClient"/>, request message, completion option, and
         /// user-defined function to implement the response validation behavior.
         /// </summary>

--- a/src/OpenStack.Net/OpenStack/Net/HttpWebException.cs
+++ b/src/OpenStack.Net/OpenStack/Net/HttpWebException.cs
@@ -25,7 +25,7 @@
         private ExceptionData _state;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="HttpResponseMessage"/> class
+        /// Initializes a new instance of the <see cref="HttpWebException"/> class
         /// with the specified response message.
         /// </summary>
         /// <remarks>

--- a/src/OpenStack.Net/OpenStack/ObjectModel/ResourceIdentifier`1.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/ResourceIdentifier`1.cs
@@ -18,7 +18,7 @@
         private readonly string _id;
 
         /// <summary>
-        /// Initialized a new instance of the <see cref="ResourceIdentifier{T}"/> class
+        /// Initializes a new instance of the <see cref="ResourceIdentifier{T}"/> class
         /// with the specified identifier.
         /// </summary>
         /// <param name="id">The resource identifier value.</param>

--- a/src/corelib/Core/Domain/Queues/QueuedMessageList.cs
+++ b/src/corelib/Core/Domain/Queues/QueuedMessageList.cs
@@ -23,7 +23,7 @@
         private QueuedMessageListId _nextPageId;
         
         /// <summary>
-        /// Initializes a new instance of the <see cref="BasicReadOnlyCollectionPage{T}"/> class
+        /// Initializes a new instance of the <see cref="QueuedMessageList"/> class
         /// that is a read-only wrapper around the specified list.
         /// </summary>
         /// <param name="list">The list to wrap.</param>

--- a/src/corelib/Core/Exceptions/SnapshotEnteredErrorStateException.cs
+++ b/src/corelib/Core/Exceptions/SnapshotEnteredErrorStateException.cs
@@ -28,7 +28,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SnapshotEnteredErrorStateException"/> with the
+        /// Initializes a new instance of the <see cref="SnapshotEnteredErrorStateException"/> class with the
         /// specified snapshot state.
         /// </summary>
         /// <param name="status">The erroneous snapshot state.</param>

--- a/src/corelib/Core/Exceptions/VolumeEnteredErrorStateException.cs
+++ b/src/corelib/Core/Exceptions/VolumeEnteredErrorStateException.cs
@@ -28,7 +28,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="VolumeEnteredErrorStateException"/> with the
+        /// Initializes a new instance of the <see cref="VolumeEnteredErrorStateException"/> class with the
         /// specified volume state.
         /// </summary>
         /// <param name="status">The erroneous volume state.</param>

--- a/src/corelib/Core/HttpStatusCodeParser.cs
+++ b/src/corelib/Core/HttpStatusCodeParser.cs
@@ -28,7 +28,7 @@ namespace net.openstack.Core
         private readonly Regex _expression;
 
         /// <summary>
-        /// Constructs a new instance of <see cref="HttpStatusCodeParser"/> for the default regular
+        /// Initializes a new instance of the <see cref="HttpStatusCodeParser"/> class for the default regular
         /// expression.
         /// </summary>
         [Obsolete("Use HttpStatusCodeParser.Default instead.")]
@@ -38,7 +38,7 @@ namespace net.openstack.Core
         }
 
         /// <summary>
-        /// Constructs a new instance of <see cref="HttpStatusCodeParser"/> for the specified regular
+        /// Initializes a new instance of the <see cref="HttpStatusCodeParser"/> class for the specified regular
         /// expression.
         /// </summary>
         /// <param name="pattern">

--- a/src/corelib/Core/ResourceIdentifier`1.cs
+++ b/src/corelib/Core/ResourceIdentifier`1.cs
@@ -18,7 +18,7 @@
         private readonly string _id;
 
         /// <summary>
-        /// Initialized a new instance of the <see cref="ResourceIdentifier{T}"/> class
+        /// Initializes a new instance of the <see cref="ResourceIdentifier{T}"/> class
         /// with the specified identifier.
         /// </summary>
         /// <param name="id">The resource identifier value.</param>

--- a/src/corelib/Providers/Rackspace/CloudAutoScaleProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudAutoScaleProvider.cs
@@ -48,7 +48,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudMonitoringProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudAutoScaleProvider"/> class with
         /// the specified values.
         /// </summary>
         /// <param name="defaultIdentity">The default identity to use for calls that do not explicitly specify an identity. If this value is <see langword="null"/>, no default identity is available so all calls must specify an explicit identity.</param>

--- a/src/corelib/Providers/Rackspace/CloudBlockStorageProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudBlockStorageProvider.cs
@@ -61,7 +61,7 @@ namespace net.openstack.Providers.Rackspace
         private readonly IBlockStorageValidator _cloudBlockStorageValidator;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// no default identity or region, and the default identity provider and REST
         /// service implementation.
         /// </summary>
@@ -69,7 +69,7 @@ namespace net.openstack.Providers.Rackspace
             : this(null, null, null, null) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// the specified default identity, no default region, and the default identity
         /// provider and REST service implementation.
         /// </summary>
@@ -78,7 +78,7 @@ namespace net.openstack.Providers.Rackspace
             : this(identity, null, null, null) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// no default identity or region, the default identity provider, and the specified
         /// REST service implementation.
         /// </summary>
@@ -87,7 +87,7 @@ namespace net.openstack.Providers.Rackspace
             : this(null, null, null, restService) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// no default identity or region, the specified identity provider, and the default
         /// REST service implementation.
         /// </summary>
@@ -96,7 +96,7 @@ namespace net.openstack.Providers.Rackspace
             : this(null, null, identityProvider, null) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// the specified default identity and identity provider, no default region, and
         /// the default REST service implementation.
         /// </summary>
@@ -106,7 +106,7 @@ namespace net.openstack.Providers.Rackspace
             : this(identity, null, identityProvider, null) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// the specified default identity and REST service implementation, no default region,
         /// and the default identity provider.
         /// </summary>
@@ -116,7 +116,7 @@ namespace net.openstack.Providers.Rackspace
             : this(identity, null, null, restService) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// the specified default identity, no default region, and the specified identity
         /// provider and REST service implementation.
         /// </summary>
@@ -127,7 +127,7 @@ namespace net.openstack.Providers.Rackspace
             : this(identity, null, identityProvider, restService) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// the specified default identity, default region, identity provider, and REST service implementation.
         /// </summary>
         /// <param name="identity">The default identity to use for calls that do not explicitly specify an identity. If this value is <see langword="null"/>, no default identity is available so all calls must specify an explicit identity.</param>
@@ -138,7 +138,7 @@ namespace net.openstack.Providers.Rackspace
             : this(identity, defaultRegion, identityProvider, restService, CloudBlockStorageValidator.Default) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudBlockStorageProvider"/> class with
         /// the specified default identity, default region, identity provider, REST service
         /// implementation, and block storage validator.
         /// </summary>

--- a/src/corelib/Providers/Rackspace/CloudNetworksProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudNetworksProvider.cs
@@ -30,7 +30,7 @@ namespace net.openstack.Providers.Rackspace
         #region Constructors
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CloudFilesProvider"/> class with
+        /// Initializes a new instance of the <see cref="CloudNetworksProvider"/> class with
         /// no default identity or region, and the default identity provider and REST
         /// service implementation.
         /// </summary>

--- a/src/corelib/Providers/Rackspace/Objects/LoadBalancers/LoadBalancerEnabledFlag.cs
+++ b/src/corelib/Providers/Rackspace/Objects/LoadBalancers/LoadBalancerEnabledFlag.cs
@@ -29,7 +29,7 @@
         private bool _enabled;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LoadBalancerEnabledFlag"/>
+        /// Initializes a new instance of the <see cref="LoadBalancerEnabledFlag"/> class
         /// during JSON deserialization.
         /// </summary>
         [JsonConstructor]
@@ -38,7 +38,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LoadBalancerEnabledFlag"/>
+        /// Initializes a new instance of the <see cref="LoadBalancerEnabledFlag"/> class
         /// with the specified value.
         /// </summary>
         /// <param name="enabled"><see langword="true"/> if the option is enabled; otherwise, <see langword="false"/>.</param>

--- a/src/corelib/Providers/Rackspace/Objects/LoadBalancers/LoadBalancerTimestamp.cs
+++ b/src/corelib/Providers/Rackspace/Objects/LoadBalancers/LoadBalancerTimestamp.cs
@@ -22,7 +22,7 @@
 #pragma warning restore 649
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LoadBalancerTimestamp"/> property
+        /// Initializes a new instance of the <see cref="LoadBalancerTimestamp"/> class
         /// during JSON deserialization.
         /// </summary>
         [JsonConstructor]

--- a/src/corelib/Providers/Rackspace/Objects/LoadBalancers/Response/ListLoadBalancerThrottlesResponse.cs
+++ b/src/corelib/Providers/Rackspace/Objects/LoadBalancers/Response/ListLoadBalancerThrottlesResponse.cs
@@ -20,7 +20,7 @@
 #pragma warning restore 649
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ListLoadBalancerThrottlesResponse"/>
+        /// Initializes a new instance of the <see cref="ListLoadBalancerThrottlesResponse"/> class
         /// during JSON deserialization.
         /// </summary>
         [JsonConstructor]

--- a/src/corelib/Providers/Rackspace/Objects/Monitoring/UpdateCheckConfiguration.cs
+++ b/src/corelib/Providers/Rackspace/Objects/Monitoring/UpdateCheckConfiguration.cs
@@ -24,7 +24,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CheckConfiguration"/> class
+        /// Initializes a new instance of the <see cref="UpdateCheckConfiguration"/> class
         /// with the specified properties.
         /// </summary>
         /// <param name="label">The friendly name of the check. If this value is <see langword="null"/>, the existing value for the check is not changed.</param>

--- a/src/corelib/Providers/Rackspace/Objects/Request/UpdateServerRequest.cs
+++ b/src/corelib/Providers/Rackspace/Objects/Request/UpdateServerRequest.cs
@@ -70,7 +70,7 @@
             public IPAddress AccessIPv6 { get; private set; }
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="UpdateServerRequest"/> class
+            /// Initializes a new instance of the <see cref="ServerUpdateDetails"/> class
             /// with the specified name and access IP addresses.
             /// </summary>
             /// <param name="name">The new name for the server. If the value is <see langword="null"/>, the server name is not changed.</param>


### PR DESCRIPTION
Thanks to @pdelvo and DotNetAnalyzers/StyleCopAnalyzers#409, this pull request fixes 26 cases where the documentation for a constructor was incorrect.