### PR TITLE
Improved AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
 - '"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\sn.exe" -k c:\projects\keys\openstack.net.portable-net45.snk'
 # Remove -SkipKeyCheck once the signing keys are added to source control
 # Remove -NoDocs once the SHFB projects are compatible with AppVeyor builds
-- powershell -Command .\build.ps1 -SkipKeyCheck -NoDocs -Verbosity minimal -Logger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- powershell -Command .\build.ps1 -SkipKeyCheck -NoDocs -Verbosity minimal -Logger "${env:ProgramFiles}\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cd ..
 # Only run tests with the attribute [TestCategory("Unit")]. These tests are expected to
 # run consistently in an automated build environment ,and failure certainly indicates

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
 - '"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\sn.exe" -k c:\projects\keys\openstack.net.portable-net45.snk'
 # Remove -SkipKeyCheck once the signing keys are added to source control
 # Remove -NoDocs once the SHFB projects are compatible with AppVeyor builds
-- powershell -Command .\build.ps1 -SkipKeyCheck -NoDocs
+- powershell -Command .\build.ps1 -SkipKeyCheck -NoDocs -Logger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cd ..
 # Only run tests with the attribute [TestCategory("Unit")]. These tests are expected to
 # run consistently in an automated build environment ,and failure certainly indicates

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
 - '"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\sn.exe" -k c:\projects\keys\openstack.net.portable-net45.snk'
 # Remove -SkipKeyCheck once the signing keys are added to source control
 # Remove -NoDocs once the SHFB projects are compatible with AppVeyor builds
-- powershell -Command .\build.ps1 -SkipKeyCheck -NoDocs -Logger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- powershell -Command .\build.ps1 -SkipKeyCheck -NoDocs -Verbosity minimal -Logger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cd ..
 # Only run tests with the attribute [TestCategory("Unit")]. These tests are expected to
 # run consistently in an automated build environment ,and failure certainly indicates

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -2,7 +2,8 @@ param (
 	[switch]$Debug,
 	[string]$VisualStudioVersion = "12.0",
 	[switch]$SkipKeyCheck,
-	[switch]$NoDocs
+	[switch]$NoDocs,
+	[string]$Logger
 )
 
 # build the solution
@@ -43,7 +44,11 @@ if (-not $?) {
 	exit $LASTEXITCODE
 }
 
-&$msbuild '/nologo' '/m' '/nr:false' '/t:rebuild' "/p:Configuration=$SolutionBuildConfig" "/p:Platform=Mixed Platforms" "/p:VisualStudioVersion=$VisualStudioVersion" $SolutionPath
+If ($Logger) {
+	$LoggerArgument = "/logger:$Logger"
+}
+
+&$msbuild '/nologo' '/m' '/nr:false' '/t:rebuild' $LoggerArgument "/p:Configuration=$SolutionBuildConfig" "/p:Platform=Mixed Platforms" "/p:VisualStudioVersion=$VisualStudioVersion" $SolutionPath
 if (-not $?) {
 	$host.ui.WriteErrorLine('Build failed, aborting!')
 	exit $LASTEXITCODE

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -78,5 +78,9 @@ if (-not (Test-Path 'nuget')) {
 	mkdir "nuget"
 }
 
-&$nuget 'pack' '..\src\corelib\corelib.nuspec' '-OutputDirectory' 'nuget' '-Prop' "Configuration=$BuildConfig" '-Version' "$Version" '-Symbols'
-&$nuget 'pack' '..\src\OpenStack.Net\OpenStack.Net.V2.nuspec' '-OutputDirectory' 'nuget' '-Prop' "Configuration=$BuildConfig" '-Version' "$VersionV2" '-Symbols'
+# The NuGet packages reference XML documentation which is post-processed by SHFB. If the -NoDocs flag is specified,
+# these files are not created so packaging will fail.
+If (-not $NoDocs) {
+	&$nuget 'pack' '..\src\corelib\corelib.nuspec' '-OutputDirectory' 'nuget' '-Prop' "Configuration=$BuildConfig" '-Version' "$Version" '-Symbols'
+	&$nuget 'pack' '..\src\OpenStack.Net\OpenStack.Net.V2.nuspec' '-OutputDirectory' 'nuget' '-Prop' "Configuration=$BuildConfig" '-Version' "$VersionV2" '-Symbols'
+}

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -3,6 +3,7 @@ param (
 	[string]$VisualStudioVersion = "12.0",
 	[switch]$SkipKeyCheck,
 	[switch]$NoDocs,
+	[string]$Verbosity = "normal",
 	[string]$Logger
 )
 
@@ -48,7 +49,7 @@ If ($Logger) {
 	$LoggerArgument = "/logger:$Logger"
 }
 
-&$msbuild '/nologo' '/m' '/nr:false' '/t:rebuild' $LoggerArgument "/p:Configuration=$SolutionBuildConfig" "/p:Platform=Mixed Platforms" "/p:VisualStudioVersion=$VisualStudioVersion" $SolutionPath
+&$msbuild '/nologo' '/m' '/nr:false' '/t:rebuild' $LoggerArgument "/verbosity:$Verbosity" "/p:Configuration=$SolutionBuildConfig" "/p:Platform=Mixed Platforms" "/p:VisualStudioVersion=$VisualStudioVersion" $SolutionPath
 if (-not $?) {
 	$host.ui.WriteErrorLine('Build failed, aborting!')
 	exit $LASTEXITCODE


### PR DESCRIPTION
* Do not create NuGet packages unless the documentation is actually built
* Enable the AppVeyor logger
* Reduce the build verbosity