### PR TITLE
Set service name for Rackspace when the value is null or empty

### DIFF
--- a/src/OpenStack.Net/Rackspace/Security/Authentication/RackspaceAuthenticationService.cs
+++ b/src/OpenStack.Net/Rackspace/Security/Authentication/RackspaceAuthenticationService.cs
@@ -44,7 +44,7 @@
         /// </remarks>
         protected override Uri GetBaseAddressImpl(Access access, string serviceType, string serviceName, string region, bool internalAddress)
         {
-            if (serviceName == string.Empty)
+            if (string.IsNullOrEmpty(serviceName))
             {
                 switch (serviceType)
                 {


### PR DESCRIPTION
Fixes #466