### PR TITLE
Enable custom static code analysis for the V2 SDK

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: 1.0.{build}
+os: Visual Studio 2015 CTP
 init:
 - git config --global core.autocrlf true
 build_script:
@@ -13,7 +14,7 @@ build_script:
 - '"C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\sn.exe" -k c:\projects\keys\openstack.net.portable-net45.snk'
 # Remove -SkipKeyCheck once the signing keys are added to source control
 # Remove -NoDocs once the SHFB projects are compatible with AppVeyor builds
-- powershell -Command .\build.ps1 -SkipKeyCheck -NoDocs -Verbosity minimal -Logger "${env:ProgramFiles}\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- powershell -Command .\build.ps1 -SkipKeyCheck -NoDocs -VisualStudioVersion "14.0" -Verbosity minimal -Logger "${env:ProgramFiles}\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cd ..
 # Only run tests with the attribute [TestCategory("Unit")]. These tests are expected to
 # run consistently in an automated build environment ,and failure certainly indicates

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" />
+</packages>

--- a/src/Docs.OpenStack.Net/SharedTokens.tokens
+++ b/src/Docs.OpenStack.Net/SharedTokens.tokens
@@ -32,6 +32,11 @@
     <para><see langword="null"/> if the underlying property was not included in the JSON representation of the object.</para>
   </item>
 
+  <item id="DefaultArrayIfNotIncluded">
+    <para>-or-</para>
+    <para>A default <see cref="ImmutableArray{T}"/> if the underlying property was not included in the JSON representation of the object.</para>
+  </item>
+
   <item id="OpenStackNotDefined">
     <note type="warning">
       <para>

--- a/src/OpenStack.Net/OpenStack.Net.net35.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net35.csproj
@@ -191,6 +191,9 @@
     <None Include="OpenStack.Net.V2.nuspec" />
     <None Include="packages.OpenStack.Net.net35.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Rackspace.KeyReporting.1.0.0\build\Rackspace.KeyReporting.targets" Condition="Exists('..\packages\Rackspace.KeyReporting.1.0.0\build\Rackspace.KeyReporting.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/OpenStack.Net/OpenStack.Net.net40.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net40.csproj
@@ -207,6 +207,9 @@
     <None Include="OpenStack.Net.V2.nuspec" />
     <None Include="packages.OpenStack.Net.net40.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/src/OpenStack.Net/OpenStack.Net.net45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net45.csproj
@@ -185,6 +185,9 @@
     <None Include="OpenStack.Net.V2.nuspec" />
     <None Include="packages.OpenStack.Net.net45.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Rackspace.KeyReporting.1.0.0\build\Rackspace.KeyReporting.targets" Condition="Exists('..\packages\Rackspace.KeyReporting.1.0.0\build\Rackspace.KeyReporting.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/OpenStack.Net/OpenStack.Net.netcore45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.netcore45.csproj
@@ -187,6 +187,9 @@
     <None Include="OpenStack.Net.V2.nuspec" />
     <None Include="packages.OpenStack.Net.netcore45.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/src/OpenStack.Net/OpenStack.Net.portable-net40.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.portable-net40.csproj
@@ -198,6 +198,9 @@
     <None Include="OpenStack.Net.V2.nuspec" />
     <None Include="packages.OpenStack.Net.portable-net40.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/src/OpenStack.Net/OpenStack.Net.portable-net45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.portable-net45.csproj
@@ -189,6 +189,9 @@
     <None Include="OpenStack.Net.V2.nuspec" />
     <None Include="packages.OpenStack.Net.portable-net45.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/AuthenticationRequirement.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/AuthenticationRequirement.cs
@@ -18,13 +18,13 @@
         /// <summary>
         /// This is the backing field for the <see cref="Scheme"/> property.
         /// </summary>
-        [JsonProperty("scheme")]
+        [JsonProperty("scheme", DefaultValueHandling = DefaultValueHandling.Ignore)]
         private string _scheme;
 
         /// <summary>
         /// This is the backing field for the <see cref="Realms"/> property.
         /// </summary>
-        [JsonProperty("realms")]
+        [JsonProperty("realms", DefaultValueHandling = DefaultValueHandling.Ignore)]
         private ImmutableArray<string> _realms;
 #pragma warning restore 649
 

--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/AuthenticationRequirement.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/AuthenticationRequirement.cs
@@ -31,6 +31,10 @@
         /// <summary>
         /// Gets the HTTP authentication scheme.
         /// </summary>
+        /// <value>
+        /// <para>The HTTP authentication scheme.</para>
+        /// <token>NullIfNotIncluded</token>
+        /// </value>
         public string Scheme
         {
             get
@@ -42,6 +46,10 @@
         /// <summary>
         /// Gets an optional collection of identity protection spaces the resource is a member of.
         /// </summary>
+        /// <value>
+        /// <para>An collection of identity protection spaces the resource is a member of.</para>
+        /// <token>DefaultArrayIfNotIncluded</token>
+        /// </value>
         public ImmutableArray<string> Realms
         {
             get

--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/HomeDocument.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/HomeDocument.cs
@@ -17,7 +17,7 @@
         /// <summary>
         /// The backing field for the <see cref="Resources"/> property.
         /// </summary>
-        [JsonProperty("resources")]
+        [JsonProperty("resources", DefaultValueHandling = DefaultValueHandling.Ignore)]
         private ImmutableDictionary<string, ResourceObject> _resources;
 #pragma warning restore 649
 

--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/ResourceObject.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/ResourceObject.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Immutable;
+    using System.Diagnostics.CodeAnalysis;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -69,6 +70,7 @@
         /// a direct link.
         /// </value>
         /// <seealso href="http://tools.ietf.org/html/rfc6570">RFC6570 (URI Template)</seealso>
+        [SuppressMessage("OpenStack.Documentation", "DocumentNullJsonValue", Justification = "The meaning of null is documented.")]
         public string HrefTemplate
         {
             get
@@ -89,6 +91,7 @@
         /// <value>
         /// The template variable mapping, or <see langword="null"/> if this is a direct link.
         /// </value>
+        [SuppressMessage("OpenStack.Documentation", "DocumentNullJsonValue", Justification = "The meaning of null is documented.")]
         public ImmutableDictionary<string, Uri> HrefVars
         {
             get

--- a/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/ResourceObject.cs
+++ b/src/OpenStack.Net/OpenStack/ObjectModel/JsonHome/ResourceObject.cs
@@ -37,7 +37,7 @@
         /// <summary>
         /// This is the backing field for the <see cref="Hints"/> property.
         /// </summary>
-        [JsonProperty("hints")]
+        [JsonProperty("hints", DefaultValueHandling = DefaultValueHandling.Ignore)]
         private ResourceHints _hints;
 #pragma warning restore 649
 

--- a/src/OpenStack.Net/OpenStack/Services/Identity/ApiVersion.cs
+++ b/src/OpenStack.Net/OpenStack/Services/Identity/ApiVersion.cs
@@ -108,7 +108,7 @@ namespace OpenStack.Services.Identity
         /// <value>
         /// <para>A collection of <seealso cref="MediaType"/> objects describing the media types supported by this
         /// version of the API.</para>
-        /// <token>NullIfNotIncluded</token>
+        /// <token>DefaultArrayIfNotIncluded</token>
         /// </value>
         public ImmutableArray<MediaType> MediaTypes
         {
@@ -125,7 +125,7 @@ namespace OpenStack.Services.Identity
         /// <value>
         /// <para>A collection of <seealso cref="Link"/> objects describing external resources related to this version of
         /// the API.</para>
-        /// <token>NullIfNotIncluded</token>
+        /// <token>DefaultArrayIfNotIncluded</token>
         /// </value>
         public ImmutableArray<Link> Links
         {

--- a/src/OpenStack.Net/OpenStack/Services/Identity/V2/Access.cs
+++ b/src/OpenStack.Net/OpenStack/Services/Identity/V2/Access.cs
@@ -74,7 +74,7 @@ namespace OpenStack.Services.Identity.V2
         /// <value>
         /// <para>A collection of <see cref="ServiceCatalogEntry"/> objects describing the services, regions, and
         /// endpoints available to an authenticated user.</para>
-        /// <token>NullIfNotIncluded</token>
+        /// <token>DefaultArrayIfNotIncluded</token>
         /// </value>
         public ImmutableArray<ServiceCatalogEntry> ServiceCatalog
         {

--- a/src/OpenStack.Net/OpenStack/Services/Identity/V2/ServiceCatalogEntry.cs
+++ b/src/OpenStack.Net/OpenStack/Services/Identity/V2/ServiceCatalogEntry.cs
@@ -85,7 +85,7 @@ namespace OpenStack.Services.Identity.V2
         /// <value>
         /// <para>A collection of <seealso cref="Endpoint"/> objects describing the available endpoints for the
         /// service.</para>
-        /// <token>NullIfNotIncluded</token>
+        /// <token>DefaultArrayIfNotIncluded</token>
         /// </value>
         public ImmutableArray<Endpoint> Endpoints
         {
@@ -101,7 +101,7 @@ namespace OpenStack.Services.Identity.V2
         /// <value>
         /// <para>A collection of <seealso cref="Link"/> objects describing external resources associated with the
         /// service.</para>
-        /// <token>NullIfNotIncluded</token>
+        /// <token>DefaultArrayIfNotIncluded</token>
         /// </value>
         public ImmutableArray<Link> EndpointsLinks
         {

--- a/src/OpenStack.Net/OpenStack/Services/Identity/V2/User.cs
+++ b/src/OpenStack.Net/OpenStack/Services/Identity/V2/User.cs
@@ -103,7 +103,7 @@ namespace OpenStack.Services.Identity.V2
         /// </summary>
         /// <value>
         /// <para>A collection of roles assigned to the user.</para>
-        /// <token>NullIfNotIncluded</token>
+        /// <token>DefaultArrayIfNotIncluded</token>
         /// </value>
         public ImmutableArray<Role> Roles
         {
@@ -120,7 +120,7 @@ namespace OpenStack.Services.Identity.V2
         /// <value>
         /// <para>A collection of <see cref="Link"/> objects describing resources related to the collection of
         /// <see cref="Roles"/>.</para>
-        /// <token>NullIfNotIncluded</token>
+        /// <token>DefaultArrayIfNotIncluded</token>
         /// </value>
         public ImmutableArray<Link> RolesLinks
         {

--- a/src/OpenStack.Net/packages.OpenStack.Net.net35.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.net35.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net35" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net35" />
   <package id="Rackspace.Collections.Immutable" version="1.1.33-beta" targetFramework="net35" />
   <package id="Rackspace.HttpClient35" version="1.0.0-beta003" targetFramework="net35" />
   <package id="Rackspace.KeyReporting" version="1.0.0" targetFramework="net35" developmentDependency="true" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.net40.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.net40.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net40" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net40" />
   <package id="Rackspace.Collections.Immutable" version="1.1.33-beta" targetFramework="net40" />
   <package id="Rackspace.KeyReporting" version="1.0.0" targetFramework="net40" developmentDependency="true" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="net40" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.net45.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.net45.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net45" />
   <package id="Rackspace.KeyReporting" version="1.0.0" targetFramework="net45" developmentDependency="true" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="net45" />
   <package id="Rackspace.Threading" version="2.0.0-alpha001" targetFramework="net45" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.netcore45.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.netcore45.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="win" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="win" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="win" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="win" />
   <package id="Rackspace.KeyReporting" version="1.0.0" targetFramework="win" developmentDependency="true" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="win" />
   <package id="Rackspace.Threading" version="2.0.0-alpha001" targetFramework="win" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.portable-net40.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.portable-net40.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Rackspace.Collections.Immutable" version="1.1.33-beta" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Rackspace.KeyReporting" version="1.0.0" targetFramework="portable-net40+sl50+win+wpa81+wp80" developmentDependency="true" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="portable-net40+sl50+win+wpa81+wp80" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.portable-net45.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.portable-net45.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Rackspace.KeyReporting" version="1.0.0" targetFramework="portable-net45+win+wpa81+wp80" developmentDependency="true" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Rackspace.Threading" version="2.0.0-alpha001" targetFramework="portable-net45+win+wpa81+wp80" />

--- a/src/OpenStackNetTests.Live/IdentityV2Tests.Shared.cs
+++ b/src/OpenStackNetTests.Live/IdentityV2Tests.Shared.cs
@@ -255,7 +255,7 @@
 
                     // check the service catalog
                     ImmutableArray<ServiceCatalogEntry> serviceCatalog = access.ServiceCatalog;
-                    Assert.IsNotNull(serviceCatalog);
+                    Assert.IsFalse(serviceCatalog.IsDefault);
                     Assert.AreNotEqual(0, serviceCatalog.Length);
                     foreach (ServiceCatalogEntry entry in serviceCatalog)
                     {

--- a/src/OpenStackNetTests.Live/OpenStackNetTests.Live.net45.csproj
+++ b/src/OpenStackNetTests.Live/OpenStackNetTests.Live.net45.csproj
@@ -93,6 +93,9 @@
     <None Include="LiveTestConfigurationTemplate.json" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/src/OpenStackNetTests.Live/packages.config
+++ b/src/OpenStackNetTests.Live/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/OpenStackNetTests.Unit/OpenStackNetTests.Unit.net45.csproj
+++ b/src/OpenStackNetTests.Unit/OpenStackNetTests.Unit.net45.csproj
@@ -163,6 +163,9 @@
       <LastGenOutput>IdentityServiceResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/src/OpenStackNetTests.Unit/Simulator/IdentityService/V2/IdentityV2AuthenticationHandler.cs
+++ b/src/OpenStackNetTests.Unit/Simulator/IdentityService/V2/IdentityV2AuthenticationHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace OpenStackNetTests.Unit.Simulator.IdentityService.V2
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Security.Claims;
     using System.Threading.Tasks;
     using Microsoft.Owin.Security;
@@ -9,6 +10,7 @@
 
     public class IdentityV2AuthenticationHandler : AuthenticationHandler<IdentityV2AuthenticationOptions>
     {
+        [SuppressMessage("OpenStack.Maintainability", "CancellationToken", Justification = "Overrides a base method from an external library.")]
         protected override Task<AuthenticationTicket> AuthenticateCoreAsync()
         {
             if (IdentityController.TokenId == null || IdentityController.TokenExpires < DateTimeOffset.Now)

--- a/src/OpenStackNetTests.Unit/packages.config
+++ b/src/OpenStackNetTests.Unit/packages.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This initial pull request enables the static code analysis using the [OpenStackNetAnalyzers](https://github.com/openstacknetsdk/OpenStackNetAnalyzers) project during an AppVeyor build, and also during development for users running Visual Studio 2015. The first build should fail if everything is configured properly due to a remaining misuse of `Assert.IsNotNull` in one of the testing libraries.