### PR TITLE
Update code analysis for Visual Studio 2015 CTP 6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-os: Visual Studio 2015 CTP
+os: Visual Studio 2015 CTP 6
 init:
 - git config --global core.autocrlf true
 build_script:

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" />
 </packages>

--- a/src/OpenStack.Net/OpenStack.Net.net35.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net35.csproj
@@ -197,7 +197,7 @@
     <None Include="packages.OpenStack.Net.net35.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha002\tools\analyzers\OpenStackNetAnalyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OpenStack.Net/OpenStack.Net.net40.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net40.csproj
@@ -213,7 +213,7 @@
     <None Include="packages.OpenStack.Net.net40.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha002\tools\analyzers\OpenStackNetAnalyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />

--- a/src/OpenStack.Net/OpenStack.Net.net45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.net45.csproj
@@ -191,7 +191,7 @@
     <None Include="packages.OpenStack.Net.net45.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha002\tools\analyzers\OpenStackNetAnalyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/OpenStack.Net/OpenStack.Net.netcore45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.netcore45.csproj
@@ -200,7 +200,7 @@
     <None Include="packages.OpenStack.Net.netcore45.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha002\tools\analyzers\OpenStackNetAnalyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />

--- a/src/OpenStack.Net/OpenStack.Net.portable-net40.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.portable-net40.csproj
@@ -204,7 +204,7 @@
     <None Include="packages.OpenStack.Net.portable-net40.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha002\tools\analyzers\OpenStackNetAnalyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />

--- a/src/OpenStack.Net/OpenStack.Net.portable-net45.csproj
+++ b/src/OpenStack.Net/OpenStack.Net.portable-net45.csproj
@@ -195,7 +195,7 @@
     <None Include="packages.OpenStack.Net.portable-net45.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha002\tools\analyzers\OpenStackNetAnalyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.net35.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.net35.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net35" />
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net35" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" targetFramework="net35" />
   <package id="Rackspace.Collections.Immutable" version="1.1.33-beta" targetFramework="net35" />
   <package id="Rackspace.HttpClient35" version="1.0.0-beta003" targetFramework="net35" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="net35" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.net40.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.net40.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net40" />
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net40" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" targetFramework="net40" />
   <package id="Rackspace.Collections.Immutable" version="1.1.33-beta" targetFramework="net40" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="net40" />
   <package id="Rackspace.Threading" version="2.0.0-alpha001" targetFramework="net40" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.net45.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.net45.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net45" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" targetFramework="net45" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="net45" />
   <package id="Rackspace.Threading" version="2.0.0-alpha001" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.netcore45.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.netcore45.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="win" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="win" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="win" />
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="win" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" targetFramework="win" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="win" />
   <package id="Rackspace.Threading" version="2.0.0-alpha001" targetFramework="win" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="win" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.portable-net40.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.portable-net40.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Rackspace.Collections.Immutable" version="1.1.33-beta" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="portable-net40+sl50+win+wpa81+wp80" />
   <package id="Rackspace.Threading" version="2.0.0-alpha001" targetFramework="portable-net40+sl50+win+wpa81+wp80" />

--- a/src/OpenStack.Net/packages.OpenStack.Net.portable-net45.config
+++ b/src/OpenStack.Net/packages.OpenStack.Net.portable-net45.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+win+wpa81+wp80" />
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Rackspace.Net.UriTemplate" version="1.0.0-beta003" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="Rackspace.Threading" version="2.0.0-alpha001" targetFramework="portable-net45+win+wpa81+wp80" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="portable-net45+win+wpa81+wp80" />

--- a/src/OpenStackNetTests.Live/OpenStackNetTests.Live.net45.csproj
+++ b/src/OpenStackNetTests.Live/OpenStackNetTests.Live.net45.csproj
@@ -94,7 +94,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha002\tools\analyzers\OpenStackNetAnalyzers.dll" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/src/OpenStackNetTests.Live/packages.config
+++ b/src/OpenStackNetTests.Live/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net45" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>

--- a/src/OpenStackNetTests.Unit/OpenStackNetTests.Unit.net45.csproj
+++ b/src/OpenStackNetTests.Unit/OpenStackNetTests.Unit.net45.csproj
@@ -165,7 +165,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha001\tools\analyzers\OpenStackNetAnalyzers.dll" />
+    <Analyzer Include="..\packages\OpenStackNetAnalyzers.1.0.0-alpha002\tools\analyzers\OpenStackNetAnalyzers.dll" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/src/OpenStackNetTests.Unit/packages.config
+++ b/src/OpenStackNetTests.Unit/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha001" targetFramework="net45" />
+  <package id="OpenStackNetAnalyzers" version="1.0.0-alpha002" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The custom code analysis features previously only worked with Visual Studio 2015 CTP 5. This pull request updates the analyzer references and AppVeyor configuration to work with CTP 6 (the latest preview release).