### PR TITLE
Move AppVeyor Build to Organization Account

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,5 @@ after_build:
 # run consistently in an automated build environment, and failure certainly indicates
 # a bug or regression in the codebase.
 test_script:
-- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=Unit" "C:\projects\openstack-net\src\OpenStackNetTests.Live\bin\Release\OpenStackNetTests.Live.dll"
-- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=Unit" "C:\projects\openstack-net\src\OpenStackNetTests.Unit\bin\Release\OpenStackNetTests.Unit.dll"
 - vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=Unit" "C:\projects\openstack-net\src\testing\integration\bin\Release\OpenStackNet.Testing.Integration.dll"
 - vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=Unit" "C:\projects\openstack-net\src\testing\unit\bin\Release\OpenStackNet.Testing.Unit.dll"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,5 +14,5 @@ after_build:
 # run consistently in an automated build environment, and failure certainly indicates
 # a bug or regression in the codebase.
 test_script:
-- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=Unit" "C:\projects\openstack-net\src\testing\integration\bin\Release\OpenStackNet.Testing.Integration.dll"
-- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=Unit" "C:\projects\openstack-net\src\testing\unit\bin\Release\OpenStackNet.Testing.Unit.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=Unit" "src\testing\integration\bin\Release\OpenStackNet.Testing.Integration.dll"
+- vstest.console /logger:Appveyor /TestCaseFilter:"TestCategory=Unit" "src\testing\unit\bin\Release\OpenStackNet.Testing.Unit.dll"

--- a/src/openstack.net.sln
+++ b/src/openstack.net.sln
@@ -70,6 +70,32 @@ Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.Current", "Do
 		{E49D9DC3-79D5-4C5E-8C38-FD5060B4E318} = {E49D9DC3-79D5-4C5E-8C38-FD5060B4E318}
 	EndProjectSection
 EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.3.2", "Documentation.History\1.3.2\Documentation.1.3.2.shfbproj", "{152CADE4-0D5C-459D-BF83-D15BB332091E}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.3.1", "Documentation.History\1.3.1\Documentation.1.3.1.shfbproj", "{A537F483-6BFE-4C43-B30A-858706E823D7}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.3.0", "Documentation.History\1.3.0\Documentation.1.3.0.shfbproj", "{895D00C5-F240-41D0-B6FE-F91898EADDDD}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.2.0", "Documentation.History\1.2.0\Documentation.1.2.0.shfbproj", "{18425383-3F99-4407-81C7-E5338CE93152}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.1.3", "Documentation.History\1.1.3\Documentation.1.1.3.shfbproj", "{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.1.2", "Documentation.History\1.1.2\Documentation.1.1.2.shfbproj", "{7D354409-687E-4397-B5E0-C305EE177E97}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.1.1", "Documentation.History\1.1.1\Documentation.1.1.1.shfbproj", "{2102A83A-0501-43E4-AD19-AF0D408457A4}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.1.0", "Documentation.History\1.1.0\Documentation.1.1.0.shfbproj", "{D822E6B6-277C-460C-A674-EBB28F10DE9C}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.0.3", "Documentation.History\1.0.3\Documentation.1.0.3.shfbproj", "{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.0.2", "Documentation.History\1.0.2\Documentation.1.0.2.shfbproj", "{55D69660-CC73-469A-94CE-A28405B7C13F}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.0.1", "Documentation.History\1.0.1\Documentation.1.0.1.shfbproj", "{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.0.0", "Documentation.History\1.0.0\Documentation.1.0.0.shfbproj", "{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "Documentation.1.3.3", "Documentation.History\1.3.3\Documentation.1.3.3.shfbproj", "{FC6B5322-98E9-49D4-BDE0-CF69847374DD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -122,6 +148,7 @@ Global
 		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
 		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
 		{EA57BD15-3742-45B8-BDE2-263F7236BAFD}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -143,6 +170,7 @@ Global
 		{60B1668C-4331-4E3D-86F6-954FFCE0CD36}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{60B1668C-4331-4E3D-86F6-954FFCE0CD36}.Release|Any CPU.Build.0 = Release|Any CPU
 		{60B1668C-4331-4E3D-86F6-954FFCE0CD36}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{60B1668C-4331-4E3D-86F6-954FFCE0CD36}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{60B1668C-4331-4E3D-86F6-954FFCE0CD36}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
 		{60B1668C-4331-4E3D-86F6-954FFCE0CD36}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
 		{60B1668C-4331-4E3D-86F6-954FFCE0CD36}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -209,6 +237,123 @@ Global
 		{04832591-1BB8-40F3-86A8-BE39F852223A}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
 		{04832591-1BB8-40F3-86A8-BE39F852223A}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
 		{04832591-1BB8-40F3-86A8-BE39F852223A}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{152CADE4-0D5C-459D-BF83-D15BB332091E}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{A537F483-6BFE-4C43-B30A-858706E823D7}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{18425383-3F99-4407-81C7-E5338CE93152}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{7D354409-687E-4397-B5E0-C305EE177E97}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{2102A83A-0501-43E4-AD19-AF0D408457A4}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{55D69660-CC73-469A-94CE-A28405B7C13F}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.ReleaseNoDocs|Any CPU.ActiveCfg = Release|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.ReleaseNoDocs|Any CPU.Build.0 = Release|Any CPU
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD}.ReleaseNoDocs|Mixed Platforms.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -225,6 +370,19 @@ Global
 		{1D084AB3-E5DB-4A72-9DAF-E51D225D5FCF} = {5EB9C284-E943-4333-9F80-7C12475ACD00}
 		{98480338-49A3-410D-8A11-E7956AEF9ACA} = {5EB9C284-E943-4333-9F80-7C12475ACD00}
 		{04832591-1BB8-40F3-86A8-BE39F852223A} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{152CADE4-0D5C-459D-BF83-D15BB332091E} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{A537F483-6BFE-4C43-B30A-858706E823D7} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{895D00C5-F240-41D0-B6FE-F91898EADDDD} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{18425383-3F99-4407-81C7-E5338CE93152} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{B2AFA1D8-2EDE-49D0-8F6A-DE705A3DACDE} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{7D354409-687E-4397-B5E0-C305EE177E97} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{2102A83A-0501-43E4-AD19-AF0D408457A4} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{D822E6B6-277C-460C-A674-EBB28F10DE9C} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{B1EC6A50-FE20-490F-A633-A0CEA5ACF7C4} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{55D69660-CC73-469A-94CE-A28405B7C13F} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{1A9A19DB-3244-4A7B-A346-AD3E6C06B49B} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{03B2E018-1C97-4EA5-ABE4-B77DE03998BE} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
+		{FC6B5322-98E9-49D4-BDE0-CF69847374DD} = {98480338-49A3-410D-8A11-E7956AEF9ACA}
 	EndGlobalSection
 	GlobalSection(TestCaseManagementSettings) = postSolution
 		CategoryFile = openstack.net.vsmdi


### PR DESCRIPTION
When I split v1/v2, I missed a few places where the build script was using v2 assets. With the following changes, the AppVeyor build should work now. As part of this, I have created a dedicated AppVeyor account for the OpenStackNETSDK organization.