### PR TITLE
Retry requests on 401 Unauthorized result

### DIFF
--- a/src/corelib/Authentication/AuthenticatedHttpClientFactory.cs
+++ b/src/corelib/Authentication/AuthenticatedHttpClientFactory.cs
@@ -1,0 +1,26 @@
+using System.Net.Http;
+using Flurl;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+
+namespace OpenStack.Authentication
+{
+    /// <summary>
+    /// Instructs Flurl to use our <see cref="AuthenticatedMessageHandler"/> for all requests.
+    /// </summary>
+    internal class AuthenticatedHttpClientFactory : DefaultHttpClientFactory
+    {
+        public override HttpClient CreateClient(Url url, HttpMessageHandler handler)
+        {
+            return new HttpClient(handler)
+            {
+                Timeout = FlurlHttp.Configuration.DefaultTimeout
+            };
+        }
+
+        public override HttpMessageHandler CreateMessageHandler()
+        {
+            return new AuthenticatedMessageHandler(base.CreateMessageHandler());
+        }
+    }
+}

--- a/src/corelib/Authentication/AuthenticatedMessageHandler.cs
+++ b/src/corelib/Authentication/AuthenticatedMessageHandler.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+
+namespace OpenStack.Authentication
+{
+    /// <summary>
+    /// Used by Flurl for all requests. Understands how to authenticate and retry when a token expires.
+    /// </summary>
+    internal class AuthenticatedMessageHandler : FlurlMessageHandler
+    {
+        public AuthenticatedMessageHandler(HttpMessageHandler innerHandler) 
+            : base(innerHandler)
+        { }
+
+        public IAuthenticationProvider AuthenticationProvider;
+
+        protected async override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            string token = await AuthenticationProvider.GetToken(cancellationToken).ConfigureAwait(false);
+            request.Headers.SetAuthToken(token);
+
+            try
+            {
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+            catch (FlurlHttpException ex)
+            {
+                if (ex.Call.HttpStatus != HttpStatusCode.Unauthorized)
+                    throw;
+            }
+                
+            // Retry with a new token
+            var retryRequest = request.Copy();
+            var retryToken = await AuthenticationProvider.GetToken(cancellationToken).ConfigureAwait(false);
+            retryRequest.Headers.SetAuthToken(retryToken);
+            return await base.SendAsync(retryRequest, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/corelib/Authentication/ServiceUrlBuilder.cs
+++ b/src/corelib/Authentication/ServiceUrlBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Flurl;
-using Flurl.Http;
 
 namespace OpenStack.Authentication
 {
@@ -24,17 +23,6 @@ namespace OpenStack.Authentication
         {
             string endpoint = await _authenticationProvider.GetEndpoint(_serviceType, _region, _useInternalUrl, cancellationToken).ConfigureAwait(false);
             return new Url(endpoint);
-        }
-
-        public async Task<string> GetToken(CancellationToken cancellationToken)
-        {
-            return await _authenticationProvider.GetToken(cancellationToken).ConfigureAwait(false);
-        }
-
-        public async Task<FlurlClient> Authenticate(FlurlClient client, CancellationToken cancellationToken)
-        {
-            string token = await GetToken(cancellationToken).ConfigureAwait(false);
-            return client.Authenticate(token);
         }
     }
 }

--- a/src/corelib/Configuration.cs
+++ b/src/corelib/Configuration.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+using Newtonsoft.Json;
+using OpenStack.Authentication;
+using OpenStack.Serialization;
+
+namespace OpenStack
+{
+    /// <summary>
+    /// A static container for global configuration settings affecting OpenStack.NET behavior.
+    /// </summary>
+    /// <threadsafety static="true" instance="false"/>
+    public static class OpenStackNet
+    {
+        private static readonly object ConfigureLock = new object();
+        private static bool _isConfigured = false;
+
+        /// <summary>
+        /// Provides thread-safe accesss to OpenStack.NET's global configuration options.
+        /// <para>
+        /// Can only be called once at application start-up, before instantiating any OpenStack.NET objects.
+        /// </para>
+        /// </summary>
+        /// <param name="configureFlurl">Addtional configuration of Flurl's global settings <seealso cref="Flurl.Http.FlurlHttp.Configure"/>.</param>
+        /// <param name="configureJson">Additional configuration of Json.NET's glboal settings <seealso cref="Newtonsoft.Json.JsonConvert.DefaultSettings"/>.</param>
+        public static void Configure(Action<FlurlHttpConfigurationOptions> configureFlurl = null, Action<JsonSerializerSettings> configureJson = null)
+        {
+            if (_isConfigured)
+                return;
+
+            lock (ConfigureLock)
+            {
+                if (_isConfigured)
+                    return;
+
+                JsonConvert.DefaultSettings = () =>
+                {
+                    // Apply our default settings
+                    var settings = new JsonSerializerSettings
+                    {
+                        DefaultValueHandling = DefaultValueHandling.Ignore,
+                        NullValueHandling = NullValueHandling.Ignore,
+                        ContractResolver = new EmptyEnumerableResolver()
+                    };
+
+                    // Apply application's default settings
+                    if (configureJson != null)
+                        configureJson(settings);
+                    return settings;
+                };
+
+                FlurlHttp.Configure(c =>
+                {
+                    // Apply our default settings
+                    c.HttpClientFactory = new AuthenticatedHttpClientFactory();
+
+                    // Apply application's default settings
+                    if (configureFlurl != null)
+                        configureFlurl(c);
+                });
+
+                _isConfigured = true;
+            }
+        }
+    }
+}

--- a/src/corelib/Extensions/FlurlExtensions.cs
+++ b/src/corelib/Extensions/FlurlExtensions.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using Flurl.Http;
+using OpenStack.Authentication;
 
 namespace Flurl
 {
@@ -46,20 +46,25 @@ namespace Flurl
             return url;
         }
 
-        public static FlurlClient Authenticate(this string url, string token)
+        public static FlurlClient Authenticate(this string url, IAuthenticationProvider authenticationProvider)
         {
-            return new Url(url).Authenticate(token);
+            return new Url(url).Authenticate(authenticationProvider);
         }
 
-        public static FlurlClient Authenticate(this Url url, string token)
+        public static FlurlClient Authenticate(this Url url, IAuthenticationProvider authenticationProvider)
         {
             var client = new FlurlClient(url, autoDispose: true);
-            return client.Authenticate(token);
+            return client.Authenticate(authenticationProvider);
         }
 
-        public static FlurlClient Authenticate(this FlurlClient client, string token)
+        public static FlurlClient Authenticate(this FlurlClient client, IAuthenticationProvider authenticationProvider)
         {
-            return client.WithHeader("X-Auth-Token", token);            
+            var authenticatedMessageHandler = client.HttpMessageHandler as AuthenticatedMessageHandler;
+            if (authenticatedMessageHandler != null)
+            {
+                authenticatedMessageHandler.AuthenticationProvider = authenticationProvider;
+            }
+            return client;
         }
     }
 }

--- a/src/corelib/Extensions/HttpHeadersExtensions.cs
+++ b/src/corelib/Extensions/HttpHeadersExtensions.cs
@@ -1,0 +1,17 @@
+using System.Net.Http.Headers;
+
+namespace System.Net.Http
+{
+    internal static class HttpHeadersExtensions
+    {
+        public const string AuthTokenHeader = "X-Auth-Token";
+
+        public static void SetAuthToken(this HttpHeaders headers, string value)
+        {
+            if (headers.Contains(AuthTokenHeader))
+                headers.Remove(AuthTokenHeader);
+
+            headers.Add(AuthTokenHeader, value);
+        }
+    }
+}

--- a/src/corelib/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/corelib/Extensions/HttpRequestMessageExtensions.cs
@@ -1,0 +1,25 @@
+namespace System.Net.Http
+{
+    internal static class HttpRequestMessageExtensions
+    {
+        public static HttpRequestMessage Copy(this HttpRequestMessage request)
+        {
+            var message = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Content = request.Content,
+                Version = request.Version
+            };
+
+            foreach (var property in request.Properties)
+            {
+                message.Properties.Add(property);
+            }
+
+            foreach (var header in request.Headers)
+            {
+                message.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+            return message;
+        }
+    }
+}

--- a/src/corelib/Providers/Rackspace/CloudIdentityProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudIdentityProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using JSIStudios.SimpleRESTServices.Client;
 using JSIStudios.SimpleRESTServices.Client.Json;
@@ -20,8 +21,6 @@ using Newtonsoft.Json.Linq;
 using OpenStack;
 using OpenStack.Authentication;
 using OpenStack.Core;
-using OpenStack.Serialization;
-using CancellationToken = System.Threading.CancellationToken;
 
 namespace net.openstack.Providers.Rackspace
 {
@@ -154,12 +153,9 @@ namespace net.openstack.Providers.Rackspace
         {
             _userAccessCache = tokenCache ?? UserAccessCache.Instance;
             _urlBase = urlBase ?? new Uri("https://identity.api.rackspacecloud.com");
-            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-            {
-                DefaultValueHandling = DefaultValueHandling.Ignore,
-                NullValueHandling = NullValueHandling.Ignore,
-                ContractResolver = new EmptyEnumerableResolver()
-            };
+
+            // If the consuming application doesn't configure this itself, this ensures that our dependencies are configured appropriately before calling any APIs
+            OpenStackNet.Configure();
         }
 
         /// <summary>

--- a/src/corelib/corelib.v4.0.csproj
+++ b/src/corelib/corelib.v4.0.csproj
@@ -75,9 +75,12 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Authentication\AuthenticatedHttpClientFactory.cs" />
+    <Compile Include="Authentication\AuthenticatedMessageHandler.cs" />
     <Compile Include="Authentication\IAuthenticationProvider.cs" />
     <Compile Include="Authentication\NamespaceDoc.cs" />
     <Compile Include="Authentication\ServiceUrlBuilder.cs" />
+    <Compile Include="Configuration.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\Flavor.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\FlavorCollection.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\NamespaceDoc.cs" />
@@ -101,6 +104,8 @@
     <Compile Include="ContentDeliveryNetworks\v1\ContentDeliveryNetworkServiceExtensions.cs" />
     <Compile Include="Core\LegacyAuthenticationProviderHelper.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
+    <Compile Include="Extensions\HttpHeadersExtensions.cs" />
+    <Compile Include="Extensions\HttpRequestMessageExtensions.cs" />
     <Compile Include="NamespaceDoc.cs" />
     <Compile Include="PageExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />

--- a/src/testing/unit/AuthenticationTests.cs
+++ b/src/testing/unit/AuthenticationTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Net;
+using Flurl.Http;
+using OpenStack.ContentDeliveryNetworks.v1;
+using Xunit;
+
+namespace OpenStack
+{
+    public class AuthenticationTests
+    {
+        [Fact]
+        public async void When401UnauthorizedIsReturned_RetryRequest()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                httpTest.RespondWith((int)HttpStatusCode.Unauthorized, "Your token has expired");
+                httpTest.RespondWithJson(new Flavor());
+
+                var service = new ContentDeliveryNetworkService(Stubs.AuthenticationProvider, "DFW");
+                var flavor = await service.GetFlavorAsync("flavor-id");
+                Assert.NotNull(flavor);
+            }
+        }
+
+        [Fact]
+        public async void When401AuthenticationFailsMultipleTimes_ThrowException()
+        {
+            using (var httpTest = new HttpTest())
+            {
+                var x = FlurlHttp.Configuration.HttpClientFactory.CreateClient(null, FlurlHttp.Configuration.HttpClientFactory.CreateMessageHandler());
+                httpTest.RespondWith((int)HttpStatusCode.Unauthorized, "Your token has expired");
+                httpTest.RespondWith((int)HttpStatusCode.Unauthorized, "Your token has expired");
+
+                var service = new ContentDeliveryNetworkService(Stubs.AuthenticationProvider, "DFW");
+                await Assert.ThrowsAsync<FlurlHttpException>(() => service.GetFlavorAsync("flavor-id"));
+            }
+        }
+    }
+}

--- a/src/testing/unit/HttpTest.cs
+++ b/src/testing/unit/HttpTest.cs
@@ -1,0 +1,51 @@
+using System.Net.Http;
+using Flurl;
+using Flurl.Http;
+using Flurl.Http.Configuration;
+using OpenStack.Authentication;
+
+namespace OpenStack
+{
+    /// <summary>
+    /// Use this instead of <see cref="Flurl.Http.Testing.HttpTest"/> for any OpenStack.NET unit tests.
+    /// <para>
+    /// This extends Flurl's default HttpTest to use <see cref="AuthenticatedMessageHandler"/> in unit tests. 
+    /// If you use the default HttpTest, then any tests which rely upon authentication handling (e.g retrying a request when a token expires) will fail.
+    /// </para>
+    /// </summary>
+    public class HttpTest : Flurl.Http.Testing.HttpTest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpTest"/> class.
+        /// </summary>
+        public HttpTest()
+        {
+            FlurlHttp.Configure(opts =>
+            {
+                opts.HttpClientFactory = new TestHttpClientFactory(this);
+            });
+        }
+
+        class TestHttpClientFactory : IHttpClientFactory
+        {
+            private readonly Flurl.Http.Testing.TestHttpClientFactory _testMessageHandler;
+            private readonly AuthenticatedHttpClientFactory _authenticatedClientFactory;
+
+            public TestHttpClientFactory(HttpTest test)
+            {
+                _testMessageHandler = new Flurl.Http.Testing.TestHttpClientFactory(test);
+                _authenticatedClientFactory = new AuthenticatedHttpClientFactory();
+            }
+
+            public HttpClient CreateClient(Url url, HttpMessageHandler handler)
+            {
+                return _authenticatedClientFactory.CreateClient(url, handler);
+            }
+
+            public HttpMessageHandler CreateMessageHandler()
+            {
+                return new AuthenticatedMessageHandler(_testMessageHandler.CreateMessageHandler());
+            }
+        }
+    }
+}

--- a/src/testing/unit/unit.csproj
+++ b/src/testing/unit/unit.csproj
@@ -97,12 +97,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsyncWebRequestTests.cs" />
+    <Compile Include="AuthenticationTests.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\ServiceOperationFailedExceptionTests.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\ServiceTests.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\FlavorTests.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\ServiceCacheTests.cs" />
     <Compile Include="Domain\Mapping\NetworkAddressDeserializationTests.cs" />
     <Compile Include="Extensions\EnumerableExtensionsTests.cs" />
+    <Compile Include="HttpTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\Rackspace\CloudNetworksValidatorTests.cs" />
     <Compile Include="Providers\Rackspace\CloudBlockStorageTests.cs" />


### PR DESCRIPTION
When a token expires, the API returns 401 Unauthorized. At that point the SDK should get a new token and retry the request. Note that this only affects new services built-out on Flurl such as CDN, the existing services already handled this properly.

The new OpenStack.HttpTest class enables unit testing this behavior. If the Flurl HttpTest class is used, then our special message handler is not and this authentication behavior isn't exercised in unit tests. Which shouldn't be an issue, unless the user was explicitly attempting to test out the retry logic.