### PR TITLE
Identity providers handle ServiceType to type key lookup

### DIFF
--- a/src/corelib/Core/Providers/OpenStackIdentityProvider.cs
+++ b/src/corelib/Core/Providers/OpenStackIdentityProvider.cs
@@ -1,4 +1,7 @@
-﻿namespace net.openstack.Core.Providers
+﻿using System.Collections.Generic;
+using OpenStack;
+
+namespace net.openstack.Core.Providers
 {
     using System;
     using net.openstack.Core.Caching;
@@ -116,6 +119,24 @@
             var userAccess = TokenCache.Get(key, refreshCallback, forceCacheRefresh);
 
             return userAccess;
+        }
+
+        // We only need to list service types for any services which are using the new service model instead of the old provider model.
+        private static readonly Dictionary<ServiceType, string> OpenStackServiceTypes = new Dictionary<ServiceType, string>
+        {
+            {ServiceType.ContentDeliveryNetwork, "cdn"}
+        };
+
+        protected override string LookupServiceTypeKey(ServiceType serviceType)
+        {
+            try
+            {
+                return OpenStackServiceTypes[serviceType];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new UnsupportedServiceException(serviceType, "OpenStack (Generic)");
+            }
         }
     }
 }

--- a/src/corelib/Exceptions/UnsupportedServiceException.cs
+++ b/src/corelib/Exceptions/UnsupportedServiceException.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace OpenStack
+{
+    /// <summary>
+    /// The exception that is thrown when a a request is made for a service type that is not supported by the current provider.
+    /// </summary>
+    /// <threadsafety static="true" instance="false"/>
+    [Serializable]
+    public sealed class UnsupportedServiceException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnsupportedServiceException"/> class.
+        /// </summary>
+        /// <param name="serviceType">The unsupported service type.</param>
+        /// <param name="provider">The OpenStack provider.</param>
+        public UnsupportedServiceException(ServiceType serviceType, String provider) 
+            : base(string.Format("The {0} service type is not supported by the {1} provider", serviceType, provider))
+        { }
+
+        private UnsupportedServiceException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/corelib/Providers/Hp/HpIdentityProvider.cs
+++ b/src/corelib/Providers/Hp/HpIdentityProvider.cs
@@ -1,4 +1,7 @@
-﻿namespace net.openstack.Providers.Hp
+﻿using System.Collections.Generic;
+using OpenStack;
+
+namespace net.openstack.Providers.Hp
 {
     using System;
     using net.openstack.Core.Caching;
@@ -181,6 +184,24 @@
             var userAccess = TokenCache.Get(key, refreshCallback, forceCacheRefresh);
 
             return userAccess;
+        }
+
+        // We only need to list service types for any services which are using the new service model instead of the old provider model.
+        private static readonly Dictionary<ServiceType, string> HpServiceTypes = new Dictionary<ServiceType, string>
+        {
+            {ServiceType.ContentDeliveryNetwork, "hpext:cdn"}
+        };
+
+        protected override string LookupServiceTypeKey(ServiceType serviceType)
+        {
+            try
+            {
+                return HpServiceTypes[serviceType];
+            }
+            catch(KeyNotFoundException)
+            {
+                throw new UnsupportedServiceException(serviceType, "HP");
+            }
         }
     }
 }

--- a/src/corelib/corelib.v4.0.csproj
+++ b/src/corelib/corelib.v4.0.csproj
@@ -103,6 +103,7 @@
     <Compile Include="ContentDeliveryNetworks\v1\ServiceStatus.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\ContentDeliveryNetworkServiceExtensions.cs" />
     <Compile Include="Core\LegacyAuthenticationProviderHelper.cs" />
+    <Compile Include="Exceptions\UnsupportedServiceException.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\HttpHeadersExtensions.cs" />
     <Compile Include="Extensions\HttpRequestMessageExtensions.cs" />

--- a/src/testing/unit/Authentication/ServiceCatalogTests.cs
+++ b/src/testing/unit/Authentication/ServiceCatalogTests.cs
@@ -1,0 +1,278 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Moq;
+using net.openstack.Core.Domain;
+using net.openstack.Core.Providers;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace OpenStack.Authentication
+{
+    public class ServiceCatalogTests
+    {
+        [Theory]
+        [MemberData("ListServiceTypes")]
+        public async void WhenUsingGenericOpenstackIdentityProvider_EveryServiceTypeCanResolveAnEndpoint(ServiceType serviceType)
+        {
+            UserAccess userAccess = JsonConvert.DeserializeObject<UserAccess>(UserAccessJson);
+            var hpIdentityProvider = new Mock<OpenStackIdentityProvider>(new Uri("http://example.com"), new CloudIdentity()){CallBase = true};
+            hpIdentityProvider.Setup(x => x.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(userAccess);
+            IAuthenticationProvider authenticationProvider = hpIdentityProvider.Object;
+
+            string result = await authenticationProvider.GetEndpoint(serviceType, "RegionOne", false, CancellationToken.None);
+            Assert.NotNull(result);
+        }
+
+        public static IEnumerable<object[]> ListServiceTypes()
+        {
+            return Enum.GetValues(typeof (ServiceType)).Cast<ServiceType>().Select(x => new object[] {x});
+        }
+
+        // Sample from https://wiki.openstack.org/wiki/API_Working_Group/Current_Design/Service_Catalog#DevStack
+        private const string UserAccessJson = @"{
+    ""metadata"": {
+      ""is_admin"": 0,
+      ""roles"": [
+        ""b4b435b99d7846048a27a32b8ebcea89"",
+        ""9fe2ff9ee4384b1894a90878d3e92bab"",
+        ""e026698b534844e8829e11d55e3a745c"",
+        ""d42cb0c16b23461d971df41c843192b5""
+      ]
+    },
+    ""serviceCatalog"": [
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8004/v1/TENANT_ID"",
+            ""id"": ""249083e367a242e5bde5833805d0ec96"",
+            ""internalURL"": ""http://111.222.333.444:8004/v1/TENANT_ID"",
+            ""publicURL"": ""http://111.222.333.444:8004/v1/TENANT_ID"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""heat"",
+        ""type"": ""orchestration""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8774/v2/TENANT_ID"",
+            ""id"": ""483b2f0455df450ba49a992ab078e0eb"",
+            ""internalURL"": ""http://111.222.333.444:8774/v2/TENANT_ID"",
+            ""publicURL"": ""http://111.222.333.444:8774/v2/TENANT_ID"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""nova"",
+        ""type"": ""compute""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:9696/"",
+            ""id"": ""33b6fbc1b4f247038c159cda2c202429"",
+            ""internalURL"": ""http://111.222.333.444:9696/"",
+            ""publicURL"": ""http://111.222.333.444:9696/"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""neutron"",
+        ""type"": ""network""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8776/v2/TENANT_ID"",
+            ""id"": ""08f5f43c145c4552b81e58e81e7fa563"",
+            ""internalURL"": ""http://111.222.333.444:8776/v2/TENANT_ID"",
+            ""publicURL"": ""http://111.222.333.444:8776/v2/TENANT_ID"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""cinderv2"",
+        ""type"": ""volumev2""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8779/v1.0/TENANT_ID"",
+            ""id"": ""3c09e566901b4adf9c76bd115c2b3da5"",
+            ""internalURL"": ""http://111.222.333.444:8779/v1.0/TENANT_ID"",
+            ""publicURL"": ""http://111.222.333.444:8779/v1.0/TENANT_ID"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""trove"",
+        ""type"": ""database""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8888/v1.0/TENANT_ID"",
+            ""id"": ""962b5253970748b6926293989070829e"",
+            ""internalURL"": ""http://111.222.333.444:8888/v1.0/TENANT_ID"",
+            ""publicURL"": ""http://111.222.333.444:8888/v1.0/TENANT_ID"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""poppy"",
+        ""type"": ""cdn""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:3333"",
+            ""id"": ""0dc5ba19c56a4136b3a64f35787557fc"",
+            ""internalURL"": ""http://111.222.333.444:3333"",
+            ""publicURL"": ""http://111.222.333.444:3333"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""s3"",
+        ""type"": ""s3""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:9292"",
+            ""id"": ""a90b1081ec4e4c89bf785de88ba4c821"",
+            ""internalURL"": ""http://111.222.333.444:9292"",
+            ""publicURL"": ""http://111.222.333.444:9292"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""glance"",
+        ""type"": ""image""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8000/v1"",
+            ""id"": ""1ea607dab4fa4c2c9f5ab7e9cba48cc7"",
+            ""internalURL"": ""http://111.222.333.444:8000/v1"",
+            ""publicURL"": ""http://111.222.333.444:8000/v1"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""heat-cfn"",
+        ""type"": ""cloudformation""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8776/v1/TENANT_ID"",
+            ""id"": ""74e3e4245a1848a5bc8933775165711d"",
+            ""internalURL"": ""http://111.222.333.444:8776/v1/TENANT_ID"",
+            ""publicURL"": ""http://111.222.333.444:8776/v1/TENANT_ID"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""cinder"",
+        ""type"": ""volume""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8773/services/Admin"",
+            ""id"": ""718512c34d264188ba06deb48e86cd2d"",
+            ""internalURL"": ""http://111.222.333.444:8773/services/Cloud"",
+            ""publicURL"": ""http://111.222.333.444:8773/services/Cloud"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""ec2"",
+        ""type"": ""ec2""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8774/v2.1/TENANT_ID"",
+            ""id"": ""5671f9e9789f49188184b5b1d6cd2d0d"",
+            ""internalURL"": ""http://111.222.333.444:8774/v2.1/TENANT_ID"",
+            ""publicURL"": ""http://111.222.333.444:8774/v2.1/TENANT_ID"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""novav21"",
+        ""type"": ""computev21""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:8080"",
+            ""id"": ""64117a0362294a2488f4e0b2e82d2391"",
+            ""internalURL"": ""http://111.222.333.444:8080/v1/AUTH_TENANT_ID"",
+            ""publicURL"": ""http://111.222.333.444:8080/v1/AUTH_TENANT_ID"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""swift"",
+        ""type"": ""object-store""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""adminURL"": ""http://111.222.333.444:35357/v2.0"",
+            ""id"": ""1fbdedef18064304954ef0cb439949d6"",
+            ""internalURL"": ""http://111.222.333.444:5000/v2.0"",
+            ""publicURL"": ""http://111.222.333.444:5000/v2.0"",
+            ""region"": ""RegionOne""
+          }
+        ],
+        ""endpoints_links"": [],
+        ""name"": ""keystone"",
+        ""type"": ""identity""
+      }
+    ],
+    ""token"": {
+      ""audit_ids"": [
+        ""S0qw2tDSSiaaj7327vGXNw""
+      ],
+      ""expires"": ""2014-12-16T04:06:16Z"",
+      ""id"": ""TOKEN_ID"",
+      ""issued_at"": ""2014-12-16T03:06:16.054920"",
+      ""tenant"": {
+        ""description"": null,
+        ""enabled"": true,
+        ""id"": ""TENANT_ID"",
+        ""name"": ""demo""
+      }
+    },
+    ""user"": {
+      ""id"": ""USER_ID"",
+      ""name"": ""demo"",
+      ""roles"": [
+        {
+          ""name"": ""Member""
+        },
+        {
+          ""name"": ""_member_""
+        },
+        {
+          ""name"": ""anotherrole""
+        },
+        {
+          ""name"": ""heat_stack_owner""
+        }
+      ],
+      ""roles_links"": [],
+      ""username"": ""demo""
+    }
+  }";
+    }
+}

--- a/src/testing/unit/HP/Authentication/ServiceCatalogTests.cs
+++ b/src/testing/unit/HP/Authentication/ServiceCatalogTests.cs
@@ -1,0 +1,282 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Moq;
+using net.openstack.Core.Domain;
+using net.openstack.Providers.Hp;
+using Newtonsoft.Json;
+using OpenStack.Authentication;
+using Xunit;
+
+namespace OpenStack.HP.Authentication
+{
+    public class ServiceCatalogTests
+    {
+        [Theory]
+        [MemberData("ListServiceTypes")]
+        public async void WhenUsingHPIdentityProvider_EveryServiceTypeCanResolveAnEndpoint(ServiceType serviceType)
+        {
+            UserAccess userAccess = JsonConvert.DeserializeObject<UserAccess>(UserAccessJson);
+            var hpIdentityProvider = new Mock<HpIdentityProvider>(new CloudIdentity()){CallBase = true};
+            hpIdentityProvider.Setup(x => x.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(userAccess);
+            IAuthenticationProvider authenticationProvider = hpIdentityProvider.Object;
+
+            string result = await authenticationProvider.GetEndpoint(serviceType, "region-a.geo-1", false, CancellationToken.None);
+            Assert.NotNull(result);
+        }
+
+        public static IEnumerable<object[]> ListServiceTypes()
+        {
+            return Enum.GetValues(typeof (ServiceType)).Cast<ServiceType>().Select(x => new object[] {x});
+        }
+
+        // Sample from https://wiki.openstack.org/wiki/API_Working_Group/Current_Design/Service_Catalog#HP_Public_Cloud
+        private const string UserAccessJson = @"{
+    ""serviceCatalog"": [
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/"",
+            ""region"": ""region-a.geo-1"",
+            ""versionId"": ""2.0"",
+            ""versionInfo"": ""https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/"",
+            ""versionList"": ""https://region-a.geo-1.identity.hpcloudsvc.com:35357""
+          },
+          {
+            ""publicURL"": ""https://region-a.geo-1.identity.hpcloudsvc.com:35357/v3/"",
+            ""region"": ""region-a.geo-1"",
+            ""versionId"": ""3.0"",
+            ""versionInfo"": ""https://region-a.geo-1.identity.hpcloudsvc.com:35357/v3/"",
+            ""versionList"": ""https://region-a.geo-1.identity.hpcloudsvc.com:35357""
+          },
+          {
+            ""publicURL"": ""https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/"",
+            ""region"": ""region-b.geo-1"",
+            ""versionId"": ""2.0"",
+            ""versionInfo"": ""https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/"",
+            ""versionList"": ""https://region-b.geo-1.identity.hpcloudsvc.com:35357""
+          },
+          {
+            ""publicURL"": ""https://region-b.geo-1.identity.hpcloudsvc.com:35357/v3/"",
+            ""region"": ""region-b.geo-1"",
+            ""versionId"": ""3.0"",
+            ""versionInfo"": ""https://region-b.geo-1.identity.hpcloudsvc.com:35357/v3/"",
+            ""versionList"": ""https://region-b.geo-1.identity.hpcloudsvc.com:35357""
+          }
+        ],
+        ""name"": ""Identity"",
+        ""type"": ""identity""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/TENANT_ID"",
+            ""publicURL2"": ""https://az-1.region-a.geo-1.ec2-compute.hpcloudsvc.com/services/Cloud"",
+            ""region"": ""az-1.region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.1"",
+            ""versionInfo"": ""https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/"",
+            ""versionList"": ""https://az-1.region-a.geo-1.compute.hpcloudsvc.com""
+          },
+          {
+            ""publicURL"": ""https://az-2.region-a.geo-1.compute.hpcloudsvc.com/v1.1/TENANT_ID"",
+            ""publicURL2"": ""https://az-2.region-a.geo-1.ec2-compute.hpcloudsvc.com/services/Cloud"",
+            ""region"": ""az-2.region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.1"",
+            ""versionInfo"": ""https://az-2.region-a.geo-1.compute.hpcloudsvc.com/v1.1/"",
+            ""versionList"": ""https://az-2.region-a.geo-1.compute.hpcloudsvc.com""
+          }
+        ],
+        ""name"": ""Compute"",
+        ""type"": ""compute""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": """",
+            ""publicURL2"": """",
+            ""region"": ""az-1.region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": """",
+            ""versionInfo"": """",
+            ""versionList"": """"
+          },
+          {
+            ""publicURL"": """",
+            ""publicURL2"": """",
+            ""region"": ""az-2.region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": """",
+            ""versionInfo"": """",
+            ""versionList"": """"
+          }
+        ],
+        ""name"": ""Networking"",
+        ""type"": ""network""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": """",
+            ""region"": ""region-a.geo-1"",
+            ""versionId"": ""2"",
+            ""versionInfo"": ""https://region-a.geo-1.usage-reporting-internal.hpcloudsvc.com:8777"",
+            ""versionList"": ""https://region-a.geo-1.usage-reporting-internal.hpcloudsvc.com:8777""
+          },
+          {
+            ""publicURL"": """",
+            ""region"": ""region-b.geo-1"",
+            ""versionId"": ""2"",
+            ""versionInfo"": ""https://region-b.geo-1.usage-reporting-internal.hpcloudsvc.com:8777"",
+            ""versionList"": ""https://region-b.geo-1.usage-reporting-internal.hpcloudsvc.com:8777""
+          }
+        ],
+        ""name"": ""Usage Reporting"",
+        ""type"": ""metering""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://region-a.geo-1.objects.hpcloudsvc.com/v1/TENANT_ID"",
+            ""region"": ""region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.0"",
+            ""versionInfo"": ""https://region-a.geo-1.objects.hpcloudsvc.com/v1.0/"",
+            ""versionList"": ""https://region-a.geo-1.objects.hpcloudsvc.com""
+          }
+        ],
+        ""name"": ""Object Storage"",
+        ""type"": ""object-store""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/TENANT_ID"",
+            ""publicURL2"": """",
+            ""region"": ""az-1.region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.1"",
+            ""versionInfo"": ""https://az-1.region-a.geo-1.compute.hpcloudsvc.com/v1.1/"",
+            ""versionList"": ""https://az-1.region-a.geo-1.compute.hpcloudsvc.com""
+          },
+          {
+            ""publicURL"": ""https://az-2.region-a.geo-1.compute.hpcloudsvc.com/v1.1/TENANT_ID"",
+            ""publicURL2"": """",
+            ""region"": ""az-2.region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.1"",
+            ""versionInfo"": ""https://az-2.region-a.geo-1.compute.hpcloudsvc.com/v1.1/"",
+            ""versionList"": ""https://az-2.region-a.geo-1.compute.hpcloudsvc.com""
+          }
+        ],
+        ""name"": ""Block Storage"",
+        ""type"": ""volume""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://region-a.geo-1.cdnmgmt.hpcloudsvc.com/v1.0/TENANT_ID"",
+            ""region"": ""region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.0"",
+            ""versionInfo"": ""https://region-a.geo-1.cdnmgmt.hpcloudsvc.com/v1.0/"",
+            ""versionList"": ""https://region-a.geo-1.cdnmgmt.hpcloudsvc.com/""
+          }
+        ],
+        ""name"": ""CDN"",
+        ""type"": ""hpext:cdn""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://glance1.uswest.hpcloud.net:9292/v1.0"",
+            ""publicURL2"": """",
+            ""region"": ""az-1.region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.0"",
+            ""versionInfo"": ""https://glance1.uswest.hpcloud.net:9292/v1.0/"",
+            ""versionList"": ""https://glance1.uswest.hpcloud.net:9292""
+          },
+          {
+            ""publicURL"": ""https://glance2.uswest.hpcloud.net:9292/v1.0"",
+            ""publicURL2"": """",
+            ""region"": ""az-2.region-a.geo-1"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.0"",
+            ""versionInfo"": ""https://glance2.uswest.hpcloud.net:9292/v1.0/"",
+            ""versionList"": ""https://glance2.uswest.hpcloud.net:9292""
+          }
+        ],
+        ""name"": ""Image Management"",
+        ""type"": ""image""
+      }
+    ],
+    ""token"": {
+      ""expires"": ""2014-12-15T03:15:25.438Z"",
+      ""id"": ""TOKEN_ID"",
+      ""tenant"": {
+        ""id"": ""TENANT_ID"",
+        ""name"": ""TOKEN_NAME""
+      }
+    },
+    ""user"": {
+      ""id"": ""USER_ID"",
+      ""name"": ""USER_NAME"",
+      ""otherAttributes"": {
+        ""domainStatus"": ""enabled"",
+        ""domainStatusCode"": ""00""
+      },
+      ""roles"": [
+        {
+          ""id"": ""00000000004003"",
+          ""name"": ""domainadmin"",
+          ""serviceId"": ""100""
+        },
+        {
+          ""id"": ""00000000004014"",
+          ""name"": ""cdn-admin"",
+          ""serviceId"": ""150"",
+          ""tenantId"": ""TENANT_ID""
+        },
+        {
+          ""id"": ""00000000004025"",
+          ""name"": ""sysadmin"",
+          ""serviceId"": ""120"",
+          ""tenantId"": ""TENANT_ID""
+        },
+        {
+          ""id"": ""00000000004022"",
+          ""name"": ""Admin"",
+          ""serviceId"": ""110"",
+          ""tenantId"": ""TENANT_ID""
+        },
+        {
+          ""id"": ""00000000004004"",
+          ""name"": ""domainuser"",
+          ""serviceId"": ""100""
+        },
+        {
+          ""id"": ""00000000004016"",
+          ""name"": ""netadmin"",
+          ""serviceId"": ""120"",
+          ""tenantId"": ""TENANT_ID""
+        },
+        {
+          ""id"": ""00000000004024"",
+          ""name"": ""user"",
+          ""serviceId"": ""140"",
+          ""tenantId"": ""TENANT_ID""
+        },
+        {
+          ""id"": ""00000000004013"",
+          ""name"": ""block-admin"",
+          ""serviceId"": ""130"",
+          ""tenantId"": ""TENANT_ID""
+        }
+      ]
+    }
+}";
+    }
+}

--- a/src/testing/unit/Rackspace/Authentication/ServiceCatalogTests.cs
+++ b/src/testing/unit/Rackspace/Authentication/ServiceCatalogTests.cs
@@ -1,0 +1,595 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Moq;
+using net.openstack.Core.Domain;
+using net.openstack.Providers.Rackspace;
+using Newtonsoft.Json;
+using OpenStack.Authentication;
+using Xunit;
+
+namespace OpenStack.Rackspace.Authentication
+{
+    public class ServiceCatalogTests
+    {
+        [Theory]
+        [MemberData("ListServiceTypes")]
+        public async void WhenUsingRackspaceIdentityProvider_EveryServiceTypeCanResolveAnEndpoint(ServiceType serviceType)
+        {
+            UserAccess userAccess = JsonConvert.DeserializeObject<UserAccess>(UserAccessJson);
+            var hpIdentityProvider = new Mock<CloudIdentityProvider>(new CloudIdentity()){CallBase = true};
+            hpIdentityProvider.Setup(x => x.GetUserAccess(It.IsAny<CloudIdentity>(), It.IsAny<bool>())).Returns(userAccess);
+            IAuthenticationProvider authenticationProvider = hpIdentityProvider.Object;
+
+            string result = await authenticationProvider.GetEndpoint(serviceType, "DFW", false, CancellationToken.None);
+            Assert.NotNull(result);
+        }
+
+        public static IEnumerable<object[]> ListServiceTypes()
+        {
+            return Enum.GetValues(typeof (ServiceType)).Cast<ServiceType>().Select(x => new object[] {x});
+        }
+
+        // Sample from https://wiki.openstack.org/wiki/API_Working_Group/Current_Design/Service_Catalog#HP_Public_Cloud
+        private const string UserAccessJson = @"{
+    ""serviceCatalog"": [
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://cdn5.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          },
+          {
+            ""publicURL"": ""https://cdn4.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          },
+          {
+            ""publicURL"": ""https://cdn1.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          },
+          {
+            ""publicURL"": ""https://cdn6.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          },
+          {
+            ""publicURL"": ""https://cdn2.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          }
+        ],
+        ""name"": ""cloudFilesCDN"",
+        ""type"": ""rax:object-cdn""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""internalURL"": ""https://snet-storage101.iad3.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""publicURL"": ""https://storage101.iad3.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          },
+          {
+            ""internalURL"": ""https://snet-storage101.syd2.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""publicURL"": ""https://storage101.syd2.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          },
+          {
+            ""internalURL"": ""https://snet-storage101.dfw1.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""publicURL"": ""https://storage101.dfw1.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          },
+          {
+            ""internalURL"": ""https://snet-storage101.hkg1.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""publicURL"": ""https://storage101.hkg1.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          },
+          {
+            ""internalURL"": ""https://snet-storage101.ord1.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""publicURL"": ""https://storage101.ord1.clouddrive.com/v1/MossoCloudFS_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""MossoCloudFS_ID""
+          }
+        ],
+        ""name"": ""cloudFiles"",
+        ""type"": ""object-store""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://syd.blockstorage.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.blockstorage.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://ord.blockstorage.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://iad.blockstorage.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://hkg.blockstorage.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudBlockStorage"",
+        ""type"": ""volume""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://iad.images.api.rackspacecloud.com/v2"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://ord.images.api.rackspacecloud.com/v2"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://hkg.images.api.rackspacecloud.com/v2"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.images.api.rackspacecloud.com/v2"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://syd.images.api.rackspacecloud.com/v2"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudImages"",
+        ""type"": ""image""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""internalURL"": ""https://snet-hkg.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""publicURL"": ""https://hkg.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""internalURL"": ""https://snet-ord.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""publicURL"": ""https://ord.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""internalURL"": ""https://snet-syd.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""publicURL"": ""https://syd.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""internalURL"": ""https://snet-dfw.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""publicURL"": ""https://dfw.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""internalURL"": ""https://snet-iad.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""publicURL"": ""https://iad.queues.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudQueues"",
+        ""type"": ""rax:queues""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://iad.bigdata.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.bigdata.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://ord.bigdata.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudBigData"",
+        ""type"": ""rax:bigdata""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://hkg.orchestration.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.orchestration.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://ord.orchestration.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://iad.orchestration.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://syd.orchestration.api.rackspacecloud.com/v1/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudOrchestration"",
+        ""type"": ""orchestration""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://syd.servers.api.rackspacecloud.com/v2/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""2"",
+            ""versionInfo"": ""https://syd.servers.api.rackspacecloud.com/v2"",
+            ""versionList"": ""https://syd.servers.api.rackspacecloud.com/""
+          },
+          {
+            ""publicURL"": ""https://dfw.servers.api.rackspacecloud.com/v2/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""2"",
+            ""versionInfo"": ""https://dfw.servers.api.rackspacecloud.com/v2"",
+            ""versionList"": ""https://dfw.servers.api.rackspacecloud.com/""
+          },
+          {
+            ""publicURL"": ""https://iad.servers.api.rackspacecloud.com/v2/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""2"",
+            ""versionInfo"": ""https://iad.servers.api.rackspacecloud.com/v2"",
+            ""versionList"": ""https://iad.servers.api.rackspacecloud.com/""
+          },
+          {
+            ""publicURL"": ""https://hkg.servers.api.rackspacecloud.com/v2/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""2"",
+            ""versionInfo"": ""https://hkg.servers.api.rackspacecloud.com/v2"",
+            ""versionList"": ""https://hkg.servers.api.rackspacecloud.com/""
+          },
+          {
+            ""publicURL"": ""https://ord.servers.api.rackspacecloud.com/v2/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""2"",
+            ""versionInfo"": ""https://ord.servers.api.rackspacecloud.com/v2"",
+            ""versionList"": ""https://ord.servers.api.rackspacecloud.com/""
+          }
+        ],
+        ""name"": ""cloudServersOpenStack"",
+        ""type"": ""compute""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://ord.autoscale.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.autoscale.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://hkg.autoscale.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://iad.autoscale.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://syd.autoscale.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""autoscale"",
+        ""type"": ""rax:autoscale""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://syd.databases.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.databases.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://ord.databases.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://iad.databases.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://hkg.databases.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudDatabases"",
+        ""type"": ""rax:database""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://iad.backup.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://hkg.backup.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://syd.backup.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.backup.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://ord.backup.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudBackup"",
+        ""type"": ""rax:backup""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://iad.networks.api.rackspacecloud.com/v2.0"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://lon.networks.api.rackspacecloud.com/v2.0"",
+            ""region"": ""LON"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://ord.networks.api.rackspacecloud.com/v2.0"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://syd.networks.api.rackspacecloud.com/v2.0"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.networks.api.rackspacecloud.com/v2.0"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://hkg.networks.api.rackspacecloud.com/v2.0"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudNetworks"",
+        ""type"": ""network""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://global.metrics.api.rackspacecloud.com/v2.0/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudMetrics"",
+        ""type"": ""rax:cloudmetrics""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://syd.loadbalancers.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://iad.loadbalancers.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://ord.loadbalancers.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://hkg.loadbalancers.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""publicURL"": ""https://dfw.loadbalancers.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudLoadBalancers"",
+        ""type"": ""rax:load-balancer""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""internalURL"": ""https://atom.prod.hkg1.us.ci.rackspace.net/TENANT_ID"",
+            ""publicURL"": ""https://hkg.feeds.api.rackspacecloud.com/TENANT_ID"",
+            ""region"": ""HKG"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""internalURL"": ""https://atom.prod.syd2.us.ci.rackspace.net/TENANT_ID"",
+            ""publicURL"": ""https://syd.feeds.api.rackspacecloud.com/TENANT_ID"",
+            ""region"": ""SYD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""internalURL"": ""https://atom.prod.iad3.us.ci.rackspace.net/TENANT_ID"",
+            ""publicURL"": ""https://iad.feeds.api.rackspacecloud.com/TENANT_ID"",
+            ""region"": ""IAD"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""internalURL"": ""https://atom.prod.dfw1.us.ci.rackspace.net/TENANT_ID"",
+            ""publicURL"": ""https://dfw.feeds.api.rackspacecloud.com/TENANT_ID"",
+            ""region"": ""DFW"",
+            ""tenantId"": ""TENANT_ID""
+          },
+          {
+            ""internalURL"": ""https://atom.prod.ord1.us.ci.rackspace.net/TENANT_ID"",
+            ""publicURL"": ""https://ord.feeds.api.rackspacecloud.com/TENANT_ID"",
+            ""region"": ""ORD"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudFeeds"",
+        ""type"": ""rax:feeds""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://monitoring.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudMonitoring"",
+        ""type"": ""rax:monitor""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://dns.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""tenantId"": ""TENANT_ID""
+          }
+        ],
+        ""name"": ""cloudDNS"",
+        ""type"": ""rax:dns""
+      },
+      {
+        ""endpoints"": [
+          {
+            ""publicURL"": ""https://servers.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""tenantId"": ""TENANT_ID"",
+            ""versionId"": ""1.0"",
+            ""versionInfo"": ""https://servers.api.rackspacecloud.com/v1.0"",
+            ""versionList"": ""https://servers.api.rackspacecloud.com/""
+          }
+        ],
+        ""name"": ""cloudServers"",
+        ""type"": ""compute""
+      },
+      {
+        ""name"": ""rackCDN"",
+        ""endpoints"": [
+          {
+            ""region"": ""DFW"",
+            ""tenantId"": ""963451"",
+            ""publicURL"": ""https://global.cdn.api.rackspacecloud.com/v1.0/TENANT_ID"",
+            ""internalURL"": ""https://global.cdn.api.rackspacecloud.com/v1.0/TENANT_ID""
+          }
+        ],
+        ""type"": ""rax:cdn""
+      }
+    ],
+    ""token"": {
+      ""RAX-AUTH:authenticatedBy"": [
+        ""PASSWORD""
+      ],
+      ""expires"": ""2014-12-11T03:26:57.420Z"",
+      ""id"": ""TOKEN_ID"",
+      ""tenant"": {
+        ""id"": ""TENANT_ID"",
+        ""name"": ""TENANT_ID""
+      }
+    },
+    ""user"": {
+      ""RAX-AUTH:defaultRegion"": ""DFW"",
+      ""id"": ""USER_ID"",
+      ""name"": ""useranme"",
+      ""roles"": [
+        {
+          ""description"": ""Checkmate Access role"",
+          ""id"": ""10000150"",
+          ""name"": ""checkmate""
+        },
+        {
+          ""description"": ""A Role that allows a user access to keystone Service methods"",
+          ""id"": ""5"",
+          ""name"": ""object-store:default"",
+          ""tenantId"": ""MossoCloudFS_ID""
+        },
+        {
+          ""description"": ""A Role that allows a user access to keystone Service methods"",
+          ""id"": ""6"",
+          ""name"": ""compute:default"",
+          ""tenantId"": ""TENANT_ID""
+        },
+        {
+          ""description"": ""User Admin Role."",
+          ""id"": ""3"",
+          ""name"": ""identity:user-admin""
+        }
+      ]
+    }
+  }";
+    }
+}

--- a/src/testing/unit/unit.csproj
+++ b/src/testing/unit/unit.csproj
@@ -76,6 +76,7 @@
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
@@ -98,12 +99,14 @@
   <ItemGroup>
     <Compile Include="AsyncWebRequestTests.cs" />
     <Compile Include="AuthenticationTests.cs" />
+    <Compile Include="Authentication\ServiceCatalogTests.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\ServiceOperationFailedExceptionTests.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\ServiceTests.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\FlavorTests.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\ServiceCacheTests.cs" />
     <Compile Include="Domain\Mapping\NetworkAddressDeserializationTests.cs" />
     <Compile Include="Extensions\EnumerableExtensionsTests.cs" />
+    <Compile Include="HP\Authentication\ServiceCatalogTests.cs" />
     <Compile Include="HttpTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\Rackspace\CloudNetworksValidatorTests.cs" />
@@ -114,6 +117,7 @@
     <Compile Include="Providers\Rackspace\ObjectProviderHelperTests.cs" />
     <Compile Include="Providers\Rackspace\ProviderBaseTests.cs" />
     <Compile Include="Providers\Rackspace\SerializationTests.cs" />
+    <Compile Include="Rackspace\Authentication\ServiceCatalogTests.cs" />
     <Compile Include="Serialization\EmptyEnumerableDeserializationTests.cs" />
     <Compile Include="Stubs.cs" />
     <Compile Include="TestCategories.cs" />


### PR DESCRIPTION
Each service provider now handles the lookup between the generic ServiceType, e.g. CDN, and the provider specific type to look for in the ServiceCatalog, e.g. rax:cdn.

_This only applies to services built on 1.4+._

@DonSchenck Can you take a look at this and let me know if you see any other pitfalls around supporting multiple OpenStack providers I may have missed?