### PR TITLE
Trace HTTP requests/errors 

### DIFF
--- a/src/corelib/OpenStackNet.cs
+++ b/src/corelib/OpenStackNet.cs
@@ -67,16 +67,33 @@ namespace OpenStack
             }
         }
 
+        /// <summary>
+        /// Provides global point for programmatically configuraing tracing
+        /// </summary>
         public static class Tracing
         {
-            public static readonly TraceSource Http = new TraceSource("Flurl.Http");
+            /// <summary>
+            /// Trace source for all HTTP requests. Default level is Error.
+            /// <para>
+            /// In your app or web.config the trace soruce name is "Flurl.Http".
+            /// </para>
+            /// </summary>
+            public static readonly TraceSource Http = new TraceSource("Flurl.Http", SourceLevels.Error);
 
+            /// <summary>
+            /// Traces a failed HTTP request
+            /// </summary>
+            /// <param name="httpCall">The Flurl HTTP call instance, containing information about the request and response.</param>
             public static void TraceFailedHttpCall(HttpCall httpCall)
             {
                 Http.TraceData(TraceEventType.Error, 0, JsonConvert.SerializeObject(httpCall, Formatting.Indented));
                 Http.Flush();
             }
 
+            /// <summary>
+            /// Traces an HTTP request
+            /// </summary>
+            /// <param name="httpCall">The Flurl HTTP call instance, containing information about the request and response.</param>
             public static void TraceHttpCall(HttpCall httpCall)
             {
                 Http.TraceData(TraceEventType.Information, 0, JsonConvert.SerializeObject(httpCall, Formatting.Indented));

--- a/src/corelib/corelib.v4.0.csproj
+++ b/src/corelib/corelib.v4.0.csproj
@@ -80,7 +80,7 @@
     <Compile Include="Authentication\IAuthenticationProvider.cs" />
     <Compile Include="Authentication\NamespaceDoc.cs" />
     <Compile Include="Authentication\ServiceUrlBuilder.cs" />
-    <Compile Include="Configuration.cs" />
+    <Compile Include="OpenStackNet.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\Flavor.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\FlavorCollection.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\NamespaceDoc.cs" />

--- a/src/testing/integration/ContentDeliveryNetworks/v1/ContentDeliveryNetworkServiceTests.cs
+++ b/src/testing/integration/ContentDeliveryNetworks/v1/ContentDeliveryNetworkServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using net.openstack.Providers.Rackspace;
 using OpenStack.Synchronous;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenStack.ContentDeliveryNetworks.v1
 {
@@ -8,8 +9,10 @@ namespace OpenStack.ContentDeliveryNetworks.v1
     {
         private readonly ContentDeliveryNetworkService _cdnService;
 
-        public ContentDeliveryNetworkServiceTests()
+        public ContentDeliveryNetworkServiceTests(ITestOutputHelper testLog)
         {
+            OpenStackNet.Tracing.Http.Listeners.Add(new XunitTraceListener(testLog));
+
             var identity = TestIdentityProvider.GetIdentityFromEnvironment();
             var authenticationProvider = new CloudIdentityProvider(identity)
             {

--- a/src/testing/integration/XunitTraceListener.cs
+++ b/src/testing/integration/XunitTraceListener.cs
@@ -1,0 +1,28 @@
+﻿using System.Diagnostics;
+using Xunit.Abstractions;
+
+namespace OpenStack
+{
+    public class XunitTraceListener : TraceListener
+    {
+        private readonly ITestOutputHelper _testLog;
+
+        public XunitTraceListener(ITestOutputHelper testLog)
+        {
+            _testLog = testLog;
+        }
+
+        public override void Write(string message)
+        {
+            if (message.StartsWith(OpenStackNet.Tracing.Http.Name))
+                return;
+
+            _testLog.WriteLine(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            _testLog.WriteLine(message);
+        }
+    }
+}

--- a/src/testing/integration/integration.csproj
+++ b/src/testing/integration/integration.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Providers\Rackspace\UserObjectStorageTests.cs" />
     <Compile Include="Providers\Rackspace\UserQueuesTests.cs" />
     <Compile Include="Providers\Rackspace\UserServerTests.cs" />
+    <Compile Include="XunitTraceListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\corelib\corelib.v4.0.csproj">

--- a/src/testing/unit/HttpTest.cs
+++ b/src/testing/unit/HttpTest.cs
@@ -23,6 +23,11 @@ namespace OpenStack
             FlurlHttp.Configure(opts =>
             {
                 opts.HttpClientFactory = new TestHttpClientFactory(this);
+                opts.AfterCall = call => // Restore handler which was nuked by the base HttpTest
+                {
+                    CallLog.Add(call);
+                    OpenStackNet.Tracing.TraceHttpCall(call); 
+                };
             });
         }
 


### PR DESCRIPTION
All HTTP requests and responses (initiated by Flurl, so new stuff only), are traced using the "Flurl.Http" source.

The default level is "Error". To enable tracing add the following to the app.config

```xml
  <system.diagnostics>
    <switches>
      <add name="Flurl.Http" value="Information" />
    </switches>
  </system.diagnostics>
```

or programmatically enable tracing via:

```csharp
OpenStackNet.Tracing.Http.Listeners.Add(myListener);
OpenStackNet.Tracing.Http.Switch.Level = SourceLevels.All;
```

Fixes #533