### PR TITLE
Run Integration Tests with CI Builds

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -8,6 +8,7 @@
     <NuGet>$(LocalAppData)\NuGet\NuGet.exe</NuGet>
     <MSBuild>&quot;$(MSBuildToolsPath)\MSBuild.exe&quot;</MSBuild>
     <XUnit>..\src\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe</XUnit>
+    <XUnitXslt>..\src\packages\xunit.runner.console.2.0.0\tools\NUnitXml.xslt</XUnitXslt>
   </PropertyGroup>
 
   <Target Name="CI">
@@ -53,12 +54,19 @@
     <MakeDir Directories="..\artifacts\TestResults\" />
     <Exec Command="$(XUnit) ..\src\testing\unit\bin\$(Configuration)\OpenStackNet.Testing.Unit.dll -xml ..\artifacts\TestResults\unit-tests.xml" ContinueOnError="true" />
     <Exec Command="$(MSTest) /testcontainer:..\src\testing\unit\bin\$(Configuration)\OpenStackNet.Testing.Unit.dll /category:Unit /resultsfile:..\artifacts\TestResults\unit.trx" ContinueOnError="true" />
-    <!--<Exec Command="$(MSTest) /testcontainer:..\src\testing\integration\bin\$(Configuration)\OpenStackNet.Testing.Integration.dll /resultsfile:..\artifacts\TestResults\integration.trx" ContinueOnError="true" WorkingDirectory="$(MSBuildThisFileDirectory)" /> -->
+
+    <!-- Convert test results to the NUnit format for easier reporting -->
+    <XslTransformation XmlInputPaths="..\artifacts\TestResults\unit-tests.xml"  XslInputPath="$(XUnitXslt)"
+      OutputPaths="..\artifacts\TestResults\unit-tests.nunit.xml" />
   </Target>
 
   <Target Name="IntegrationTest" DependsOnTargets="Build">
     <MakeDir Directories="..\artifacts\TestResults\" />
     <Exec Command="$(XUnit) ..\src\testing\integration\bin\$(Configuration)\OpenStackNet.Testing.Integration.dll -xml ..\artifacts\TestResults\integration-tests.xml -notrait ci=false" ContinueOnError="true" />
+
+    <!-- Convert test results to the NUnit format for easier reporting -->
+    <XslTransformation XmlInputPaths="..\artifacts\TestResults\integration-tests.xml"  XslInputPath="$(XUnitXslt)"
+      OutputPaths="..\artifacts\TestResults\integration-tests.nunit.xml" />
   </Target>
 
   <Target Name="Package" DependsOnTargets="Build;Documentation">

--- a/build/build.proj
+++ b/build/build.proj
@@ -18,6 +18,7 @@
     <CallTarget Targets="Build" />
     <CallTarget Targets="Documentation" />
     <CallTarget Targets="UnitTest" />
+    <CallTarget Targets="IntegrationTest" />
     <CallTarget Targets="Package" />
   </Target>
 
@@ -56,8 +57,8 @@
   </Target>
 
   <Target Name="IntegrationTest" DependsOnTargets="Build">
-    <Error Condition=" '$(OPENSTACKNET_USER)' == '' OR '$(OPENSTACKNET_APIKEY)' == '' " Text="You must set the OPENSTACKNET_USER and OPENSTACKNET_APIKEY environment variables, logout then login in order to run the integration tests." />
-    <Exec Command="$(XUnit) ..\src\testing\integration\bin\$(Configuration)\OpenStackNet.Testing.Integration.dll -xml ..\artifacts\TestResults\integration-tests.xml" ContinueOnError="true" />
+    <MakeDir Directories="..\artifacts\TestResults\" />
+    <Exec Command="$(XUnit) ..\src\testing\integration\bin\$(Configuration)\OpenStackNet.Testing.Integration.dll -xml ..\artifacts\TestResults\integration-tests.xml -notrait ci=false" ContinueOnError="true" />
   </Target>
 
   <Target Name="Package" DependsOnTargets="Build;Documentation">

--- a/src/testing/integration/ContentDeliveryNetworks/v1/ContentDeliveryNetworkServiceTests.cs
+++ b/src/testing/integration/ContentDeliveryNetworks/v1/ContentDeliveryNetworkServiceTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 
 namespace OpenStack.ContentDeliveryNetworks.v1
 {
+    [Trait("ci","false")]
     public class ContentDeliveryNetworkServiceTests
     {
         private readonly ContentDeliveryNetworkService _cdnService;

--- a/src/testing/integration/ContentDeliveryNetworks/v1/ServiceTests.cs
+++ b/src/testing/integration/ContentDeliveryNetworks/v1/ServiceTests.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace OpenStack.ContentDeliveryNetworks.v1
 {
+    [Trait("ci","false")]
     public class ServiceTests
     {
         private readonly ContentDeliveryNetworkService _cdnService;

--- a/src/testing/integration/XunitTraceListener.cs
+++ b/src/testing/integration/XunitTraceListener.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using Xunit.Abstractions;
 
 namespace OpenStack
@@ -17,12 +18,24 @@ namespace OpenStack
             if (message.StartsWith(OpenStackNet.Tracing.Http.Name))
                 return;
 
-            _testLog.WriteLine(message);
+            TryLog(message);
         }
 
         public override void WriteLine(string message)
         {
-            _testLog.WriteLine(message);
+            TryLog(message);
+        }
+
+        private void TryLog(string message)
+        {
+            try
+            {
+                _testLog.WriteLine(message);
+            }
+            catch (InvalidOperationException)
+            {
+                // Unable to log to xunit because it thinks no test is active...
+            }
         }
     }
 }


### PR DESCRIPTION
The integration tests will be executed for all CI builds (i.e. master, release branches and pull requests). Anything marked with `[Trait("ci", "false")]` will be skipped.

At the moment the CI environment doesn't have Poppy installed, so the CDN tests are skipped.

Closes #546 