### PR TITLE
Mark Networking v1 as Deprecated

### DIFF
--- a/src/corelib/Core/Providers/INetworksProvider.cs
+++ b/src/corelib/Core/Providers/INetworksProvider.cs
@@ -7,9 +7,11 @@ using net.openstack.Core.Exceptions.Response;
 namespace net.openstack.Core.Providers
 {
     /// <summary>
+    /// <para>DEPRECATED. Use <see cref="OpenStack.Networking.v2.NetworkingService"/> or Rackspace.CloudNetworks.v2.CloudNetworkService (from the Rackspace NuGet package).</para>
     /// Represents a provider for the OpenStack Networking service.
     /// </summary>
     /// <seealso href="http://docs.openstack.org/api/openstack-network/2.0/content/">OpenStack Networking API v2.0 Reference</seealso>
+    [Obsolete("This will be removed in v2.0. Use OpenStack.Networking.v2.NetworkingService or Rackspace.CloudNetworks.v2.CloudNetworkService (from the Rackspace NuGet package).")]
     public interface INetworksProvider
     {
         /// <summary>

--- a/src/corelib/OpenStack.csproj
+++ b/src/corelib/OpenStack.csproj
@@ -27,6 +27,7 @@
     <DocumentationFile>bin\v4.0\Debug\openstacknet.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/corelib/Providers/Rackspace/CloudNetworksProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudNetworksProvider.cs
@@ -14,6 +14,7 @@ using net.openstack.Providers.Rackspace.Objects.Response;
 namespace net.openstack.Providers.Rackspace
 {
     /// <summary>
+    /// <para>DEPRECATED. Use <see cref="OpenStack.Networking.v2.NetworkingService"/> or Rackspace.CloudNetworks.v2.CloudNetworkService (from the Rackspace NuGet package).</para>
     /// <para>The Cloud Networks Provider enable simple access to the Rackspace Cloud Network Services.
     /// Cloud Networks lets you create a virtual Layer 2 network, known as an isolated network, 
     /// which gives you greater control and security when you deploy web applications.</para>
@@ -23,6 +24,7 @@ namespace net.openstack.Providers.Rackspace
     /// <see cref="INetworksProvider"/>
     /// <inheritdoc />
     /// <threadsafety static="true" instance="false"/>
+    [Obsolete("This will be removed in v2.0. Use OpenStack.Networking.v2.NetworkingService or Rackspace.CloudNetworks.v2.CloudNetworkService (from the Rackspace NuGet package).")]
     public class CloudNetworksProvider : ProviderBase<INetworksProvider>, INetworksProvider
     {
         private readonly HttpStatusCode[] _validResponseCode = new[] { HttpStatusCode.OK, HttpStatusCode.Created, HttpStatusCode.Accepted };

--- a/src/testing/integration/OpenStack.IntegrationTests.csproj
+++ b/src/testing/integration/OpenStack.IntegrationTests.csproj
@@ -30,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Since the OpenStack Networking v1 API is no longer supported, v2 will completely replace v1. I've marked v1 with the `[Obsolete]` attribute which will cause compiler warnings for anyone using them. 

Since we have Treat Warnings as Errors enabled, I've added an exception for this warning. Once we hit v2.0 I'll remove that exception.

Fixes #531 