### PR TITLE
Address Version Conflict in Json.NET

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,13 @@
   <config>
     <add key="repositorypath" value="src/packages" />
   </config>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2" />
+    <add key="OpenStackNetSDK" value="https://www.myget.org/F/openstacknetsdk/api/v2" />
+  </packageSources>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)"  />
+  </activePackageSource>
   <packageRestore>
     <add key="enabled" value="True" />
     <add key="automatic" value="True" />

--- a/build/build.proj
+++ b/build/build.proj
@@ -5,10 +5,11 @@
     <Configuration>Debug</Configuration>
     <Version>1.5.0.0</Version>
 
+    <ILMerge>$(MSBuildThisFileDirectory.Replace('build\','src'))\packages\ILMerge.2.14.1208\tools\ILMerge.exe</ILMerge>
     <NuGet>$(LocalAppData)\NuGet\NuGet.exe</NuGet>
     <MSBuild>&quot;$(MSBuildToolsPath)\MSBuild.exe&quot;</MSBuild>
-    <XUnit>..\src\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe</XUnit>
-    <XUnitXslt>..\src\packages\xunit.runner.console.2.0.0\tools\NUnitXml.xslt</XUnitXslt>
+    <XUnit>$(MSBuildThisFileDirectory.Replace('build\','src'))\packages\xunit.runner.console.2.0.0\tools\xunit.console.exe</XUnit>
+    <XUnitXslt>$(MSBuildThisFileDirectory.Replace('build\','src'))\packages\xunit.runner.console.2.0.0\tools\NUnitXml.xslt</XUnitXslt>
   </PropertyGroup>
 
   <Target Name="CI">
@@ -70,6 +71,10 @@
   </Target>
 
   <Target Name="Package" DependsOnTargets="Build;Documentation">
+    <MakeDir Directories="..\src\corelib\bin\v4.0\$(Configuration)\deploy" />
+    <Exec Command="$(ILMerge) /t:library /v4 /out:deploy/openstacknet.dll openstacknet.dll SimpleRESTServices.dll"
+          WorkingDirectory="..\src\corelib\bin\v4.0\$(Configuration)" />
+
     <MakeDir Directories="..\artifacts\packages\" />
     <Exec Command="$(NuGet) pack ..\src\corelib\corelib.nuspec -OutputDirectory ..\artifacts\packages -Prop Configuration=$(Configuration) -Version $(Version) -Symbols" />
   </Target>

--- a/src/Samples/CPPCodeSamples/CPPCodeSamples.vcxproj
+++ b/src/Samples/CPPCodeSamples/CPPCodeSamples.vcxproj
@@ -75,7 +75,7 @@
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SimpleRESTServices">
-      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1-json6\lib\net40\SimpleRESTServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Samples/CSharpCodeSamples/CSharpCodeSamples.csproj
+++ b/src/Samples/CSharpCodeSamples/CSharpCodeSamples.csproj
@@ -40,7 +40,7 @@
     </Reference>
     <Reference Include="SimpleRESTServices, Version=1.3.0.0, Culture=neutral, PublicKeyToken=8965cea5c205d3a3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1-json6\lib\net40\SimpleRESTServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Samples/FSharpCodeSamples/FSharpCodeSamples.fsproj
+++ b/src/Samples/FSharpCodeSamples/FSharpCodeSamples.fsproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SimpleRESTServices">
-      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1-json6\lib\net40\SimpleRESTServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Samples/VBCodeSamples/VBCodeSamples.vbproj
+++ b/src/Samples/VBCodeSamples/VBCodeSamples.vbproj
@@ -53,7 +53,7 @@
     </Reference>
     <Reference Include="SimpleRESTServices, Version=1.3.0.0, Culture=neutral, PublicKeyToken=8965cea5c205d3a3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1-json6\lib\net40\SimpleRESTServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/src/corelib/OpenStack.csproj
+++ b/src/corelib/OpenStack.csproj
@@ -66,7 +66,7 @@
     </Reference>
     <Reference Include="SimpleRESTServices, Version=1.3.0.0, Culture=neutral, PublicKeyToken=8965cea5c205d3a3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+      <HintPath>..\packages\SimpleRESTServices.1.3.0.1-json6\lib\net40\SimpleRESTServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/corelib/corelib.nuspec
+++ b/src/corelib/corelib.nuspec
@@ -15,7 +15,6 @@
     <tags>openstack</tags>
     <dependencies>
       <group targetFramework="4.5">
-        <dependency id="SimpleRESTServices" version="[1.3.0.1]" />
         <dependency id="Newtonsoft.Json" version="6.0.4" />
         <dependency id="Flurl.Http.Signed" version="0.6.2.2015062601" />
         <dependency id="Marvin.JsonPatch.Signed" version="0.7.0" />
@@ -25,8 +24,8 @@
   <files>
 
     <!-- Runtime libraries -->
-    <file src="bin\v4.0\$Configuration$\openstacknet.dll" target="lib\net45"/>
-    <file src="bin\v4.0\$Configuration$\openstacknet.pdb" target="lib\net45"/>
+    <file src="bin\v4.0\$Configuration$\deploy\openstacknet.dll" target="lib\net45"/>
+    <file src="bin\v4.0\$Configuration$\deploy\openstacknet.pdb" target="lib\net45"/>
     <file src="..\..\artifacts\docs\Api\v4.0\openstacknet.xml" target="lib\net45"/>
 
     <!-- Source code -->

--- a/src/corelib/packages.config
+++ b/src/corelib/packages.config
@@ -4,5 +4,6 @@
   <package id="Flurl.Signed" version="1.0.8" targetFramework="net45" />
   <package id="Marvin.JsonPatch.Signed" version="0.7.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net40" />
+  <package id="SimpleRESTServices" version="1.3.0.1-json6" targetFramework="net40" />
+  <package id="ILMerge" version="2.14.1208" targetFramework="net40" />
 </packages>

--- a/src/openstack.net.sln
+++ b/src/openstack.net.sln
@@ -26,6 +26,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{EFFA0DAE-1829-4783-92CF-390CFCE22E43}"
 	ProjectSection(SolutionItems) = preProject
 		..\build\build.proj = ..\build\build.proj
+		..\NuGet.config = ..\NuGet.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenStack", "corelib\OpenStack.csproj", "{1A4FB67F-8642-4402-B931-118955AE7538}"

--- a/src/testing/integration/OpenStack.IntegrationTests.csproj
+++ b/src/testing/integration/OpenStack.IntegrationTests.csproj
@@ -76,7 +76,7 @@
     </Reference>
     <Reference Include="SimpleRESTServices, Version=1.3.0.0, Culture=neutral, PublicKeyToken=8965cea5c205d3a3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1-json6\lib\net40\SimpleRESTServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/testing/unit/OpenStack.UnitTests.csproj
+++ b/src/testing/unit/OpenStack.UnitTests.csproj
@@ -69,7 +69,7 @@
     </Reference>
     <Reference Include="SimpleRESTServices, Version=1.3.0.0, Culture=neutral, PublicKeyToken=8965cea5c205d3a3, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1\lib\net40\SimpleRESTServices.dll</HintPath>
+      <HintPath>..\..\packages\SimpleRESTServices.1.3.0.1-json6\lib\net40\SimpleRESTServices.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">


### PR DESCRIPTION
This fixes #554.

I have forked SimpleRestServices to our github organization: https://github.com/openstacknetsdk/SimpleRestServices.

* Custom build of SimpleRestServices which uses Json.NET v6 is hosted on [myget].
* We use SimpleRestServices.1.3.0.1-json6 for our build.
* After we build, ILMerge is used to bundle SimpleRestServices with openstacknet.dll. I had to keep the merged SimpleRestServices classes public because our method signatures expose their classes.
* Our nuget package distributes the bundled openstacknet.dll.

Existing openstack.net users can remove SimpleRestServices from their packages.config and project references, after installing the new version of OpenStack.NET. If they already had an app.config with binding redirects, those can be removed as well.

New OpenStack.NET users will never be exposed to the version conflict and no action is required either now or when the dependency is fully removed in v2.

[myget]: http://myget.org/gallery/openstacknetsdk