### PR TITLE
Use GitVersion to Generate Unique Prerelease Tags

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -3,7 +3,11 @@
 
   <PropertyGroup>
     <Configuration>Debug</Configuration>
-    <Version>1.5.0.1-beta1</Version>
+
+    <!-- Note: We won't start using semver until v2 -->
+    <PrereleaseTag Condition=" '$(bamboo_GitVersion_BuildMetadata)' != '' ">-beta$(bamboo_GitVersion_BuildMetadata)</PrereleaseTag>
+    <PrereleaseTag Condition=" '$(bamboo_GitVersion_BuildMetadata)' == '' ">-SNAPSHOT</PrereleaseTag>
+    <Version>1.5.0.1$(PrereleaseTag)</Version>
 
     <ILMerge>$(MSBuildThisFileDirectory.Replace('build\','src'))\packages\ILMerge.2.14.1208\tools\ILMerge.exe</ILMerge>
     <NuGet>$(LocalAppData)\NuGet\NuGet.exe</NuGet>
@@ -25,6 +29,7 @@
   </Target>
 
   <Target Name="Build" DependsOnTargets="RestorePackages">
+    <Message Text="Building version $(Version)..." />
     <Exec Command="$(MSBuild) ..\src\openstack.net.sln /p:Configuration=$(Configuration) /nologo /v:minimal" />
   </Target>
 


### PR DESCRIPTION
While MyGet lets us overwrite existing versions, the local machine cache screws that up anyhow. With this change the version number generated for prereleases will bump automatically, e.g. `1.5.0.1-beta14`, `1.5.0.1-beta15`... The final number is the # of commits since the last release tag.

When build.sh is used, instead of generating beta releases, it will generate a snapshot version, e.g. `1.5.0.1-SNAPSHOT`.

We won't use semver until v2.0, so until then we aren't taking full advantage of GitVersion. At which point the entire version number can be generated and AssemblyInfo files updated for us.