### PR TITLE
Pin Dependencies

### DIFF
--- a/build/build.proj
+++ b/build/build.proj
@@ -7,7 +7,7 @@
     <!-- Note: We won't start using semver until v2 -->
     <PrereleaseTag Condition=" '$(bamboo_GitVersion_BuildMetadata)' != '' ">-beta$(bamboo_GitVersion_BuildMetadata)</PrereleaseTag>
     <PrereleaseTag Condition=" '$(bamboo_GitVersion_BuildMetadata)' == '' ">-SNAPSHOT</PrereleaseTag>
-    <Version>1.5.0.1</Version>
+    <Version>1.5.0.2</Version>
 
     <ILMerge>$(MSBuildThisFileDirectory.Replace('build\','src'))\packages\ILMerge.2.14.1208\tools\ILMerge.exe</ILMerge>
     <NuGet>$(LocalAppData)\NuGet\NuGet.exe</NuGet>

--- a/src/corelib/corelib.nuspec
+++ b/src/corelib/corelib.nuspec
@@ -15,9 +15,9 @@
     <tags>openstack</tags>
     <dependencies>
       <group targetFramework="4.5">
-        <dependency id="Newtonsoft.Json" version="6.0.4" />
-        <dependency id="Flurl.Http.Signed" version="0.6.2.2015062601" />
-        <dependency id="Marvin.JsonPatch.Signed" version="0.7.0" />
+        <dependency id="Newtonsoft.Json" version="[6.0.1,7.0)" />
+        <dependency id="Flurl.Http.Signed" version="[0.6.2.2015062601, 0.7)" />
+        <dependency id="Marvin.JsonPatch.Signed" version="[0.7.0]" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
The new version of NuGet can now be configured to install the latest version of dependencies, instead of the old default to install the lowest version. I've updated our NuGet package spec to set an upper limit on our dependencies to account for this new behavior.

Fixes #566 