### PR TITLE
Upgrade to Flurl.Http 0.7

### DIFF
--- a/src/corelib/Authentication/AuthenticatedHttpClientFactory.cs
+++ b/src/corelib/Authentication/AuthenticatedHttpClientFactory.cs
@@ -16,7 +16,7 @@ namespace OpenStack.Authentication
         {
             return new HttpClient(handler)
             {
-                Timeout = FlurlHttp.Configuration.DefaultTimeout
+                Timeout = FlurlHttp.GlobalSettings.DefaultTimeout
             };
         }
 

--- a/src/corelib/Compute/v2_6/Console.cs
+++ b/src/corelib/Compute/v2_6/Console.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json;
 using OpenStack.Serialization;
 
 namespace OpenStack.Compute.v2_6
@@ -12,11 +13,13 @@ namespace OpenStack.Compute.v2_6
         /// <summary>
         /// The console type.
         /// </summary>
+        [JsonProperty("type")]
         public RemoteConsoleType Type { get; set; }
 
         /// <summary>
         /// The console URL.
         /// </summary>
+        [JsonProperty("url")]
         public Uri Url { get; set; }
     }
 }

--- a/src/corelib/ContentDeliveryNetworks/v1/ServiceOperationFailedException.cs
+++ b/src/corelib/ContentDeliveryNetworks/v1/ServiceOperationFailedException.cs
@@ -27,7 +27,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
         private ServiceOperationFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
-            Errors = JsonConvert.DeserializeObject<IEnumerable<ServiceError>>(info.GetString("service_errors"));
+            Errors = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<IEnumerable<ServiceError>>(info.GetString("service_errors"));
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             // ReSharper disable once ExceptionNotDocumented
-            info.AddValue("service_errors", JsonConvert.SerializeObject(Errors));
+            info.AddValue("service_errors", OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(Errors));
             base.GetObjectData(info, context);
         }
     }

--- a/src/corelib/Extensions/FlurlExtensions.cs
+++ b/src/corelib/Extensions/FlurlExtensions.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Flurl.Http;
+using OpenStack;
 using OpenStack.Authentication;
 
 // ReSharper disable once CheckNamespace
@@ -106,8 +107,28 @@ namespace Flurl.Extensions
         /// </returns>
         public static PreparedRequest Authenticate(this Url url, IAuthenticationProvider authenticationProvider)
         {
-            var client = new PreparedRequest(url, autoDispose: true);
-            return client.Authenticate(authenticationProvider);
+            return url.PrepareRequest().Authenticate(authenticationProvider);
+        }
+
+        /// <summary>
+        /// Builds a prepared Flurl request which can be executed at a later time.
+        /// </summary>
+        /// <param name="url">The URL.</param>
+        public static PreparedRequest PrepareRequest(this string url)
+        {
+            return new Url(url).PrepareRequest();
+        }
+
+        /// <summary>
+        /// Builds a prepared Flurl request which can be executed at a later time.
+        /// </summary>
+        /// <param name="url">The URL.</param>
+        public static PreparedRequest PrepareRequest(this Url url)
+        {
+            return new PreparedRequest(url, autoDispose: true)
+            {
+                Settings = OpenStackNet.Configuration.FlurlHttpSettings
+            };
         }
 
         /// <summary>

--- a/src/corelib/Extensions/FlurlExtensions.cs
+++ b/src/corelib/Extensions/FlurlExtensions.cs
@@ -21,17 +21,6 @@ namespace Flurl.Extensions
         /// <summary>
         /// Allow a specific HTTP status code.
         /// </summary>
-        /// <param name="client">The client.</param>
-        /// <param name="statusCode">The allowed status code.</param>
-        /// <returns></returns>
-        public static FlurlClient AllowHttpStatus(this FlurlClient client, HttpStatusCode statusCode)
-        {
-            return client.AllowHttpStatus(((int)statusCode).ToString(CultureInfo.InvariantCulture));
-        }
-
-        /// <summary>
-        /// Allow a specific HTTP status code.
-        /// </summary>
         /// <param name="url">The URL.</param>
         /// <param name="statusCode">The allowed status code.</param>
         /// <returns></returns>

--- a/src/corelib/Extensions/TypeExtensions.cs
+++ b/src/corelib/Extensions/TypeExtensions.cs
@@ -32,6 +32,15 @@ namespace System.Extensions
         }
 
         /// <summary />
+        public static T Clone<T>(this T src)
+            where T : new()
+        {
+            var dest = new T();
+            src.CopyProperties(dest);
+            return dest;
+        }
+
+        /// <summary />
         public static void CopyProperties<T>(this T src, T dest)
         {
             foreach (PropertyDescriptor srcProp in TypeDescriptor.GetProperties(src))

--- a/src/corelib/Flurl/PreparedRequest.cs
+++ b/src/corelib/Flurl/PreparedRequest.cs
@@ -2,8 +2,6 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Flurl;
-using Flurl.Http;
 using Flurl.Http.Content;
 
 // ReSharper disable once CheckNamespace
@@ -97,7 +95,7 @@ namespace Flurl.Http
         public PreparedRequest PreparePatchJson(object data, CancellationToken cancellationToken = default(CancellationToken))
         {
             Verb = new HttpMethod("PATCH");
-            Content = new CapturedJsonContent(data);
+            Content = new CapturedJsonContent(Settings.JsonSerializer.Serialize(data));
             CancellationToken = cancellationToken;
             return this;
         }
@@ -108,7 +106,7 @@ namespace Flurl.Http
         public PreparedRequest PreparePostJson(object data, CancellationToken cancellationToken = default(CancellationToken))
         {
             Verb = HttpMethod.Post;
-            Content = new CapturedJsonContent(data);
+            Content = new CapturedJsonContent(Settings.JsonSerializer.Serialize(data));
             CancellationToken = cancellationToken;
             return this;
         }
@@ -119,7 +117,7 @@ namespace Flurl.Http
         public PreparedRequest PreparePutJson(object data, CancellationToken cancellationToken = default(CancellationToken))
         {
             Verb = HttpMethod.Put;
-            Content = new CapturedJsonContent(data);
+            Content = new CapturedJsonContent(Settings.JsonSerializer.Serialize(data));
             CancellationToken = cancellationToken;
             return this;
         }

--- a/src/corelib/OpenStack.csproj
+++ b/src/corelib/OpenStack.csproj
@@ -48,12 +48,12 @@
     <AssemblyOriginatorKeyFile Condition="'$(KeyConfiguration)' != 'Final'">..\..\build\keys\OpenStackNetV1.dev.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flurl, Version=1.0.8.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
-      <HintPath>..\packages\Flurl.Signed.1.0.8\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
+    <Reference Include="Flurl, Version=1.0.10.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
+      <HintPath>..\packages\Flurl.Signed.1.0.10\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Flurl.Http, Version=0.6.2.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
-      <HintPath>..\packages\Flurl.Http.Signed.0.6.2.2015062601\lib\net45\Flurl.Http.dll</HintPath>
+    <Reference Include="Flurl.Http, Version=0.7.0.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
+      <HintPath>..\packages\Flurl.Http.Signed.0.7.0\lib\net45\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Marvin.JsonPatch, Version=0.7.0.0, Culture=neutral, PublicKeyToken=686c63b2d045ab44, processorArchitecture=MSIL">

--- a/src/corelib/Providers/Rackspace/CloudIdentityProvider.cs
+++ b/src/corelib/Providers/Rackspace/CloudIdentityProvider.cs
@@ -160,9 +160,6 @@ namespace net.openstack.Providers.Rackspace
         {
             _userAccessCache = tokenCache ?? UserAccessCache.Instance;
             _urlBase = urlBase ?? new Uri("https://identity.api.rackspacecloud.com");
-
-            // If the consuming application doesn't configure this itself, this ensures that our dependencies are configured appropriately before calling any APIs
-            OpenStackNet.Configure();
         }
 
         /// <summary>

--- a/src/corelib/Testing/HttpTest.cs
+++ b/src/corelib/Testing/HttpTest.cs
@@ -21,21 +21,19 @@ namespace OpenStack.Testing
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpTest"/> class.
         /// </summary>
-        /// <param name="configureFlurl">Addtional configuration of the OpenStack.NET Flurl client settings <seealso cref="Flurl.Http.FlurlHttp.Configure" />.</param>
         /// <param name="configure">Additional configuration of OpenStack.NET's global settings.</param>
-        public HttpTest(Action<FlurlHttpSettings> configureFlurl = null, Action<OpenStackNetConfigurationOptions> configure = null)
+        public HttpTest(Action<OpenStackNetConfigurationOptions> configure = null)
         {
-            Action<FlurlHttpSettings> setFlurlTestMode = opts =>
+            Action<FlurlHttpSettings> setTestMode = settings =>
             {
-                configureFlurl?.Invoke(opts);
-                opts.HttpClientFactory = new TestHttpClientFactory(this);
-                opts.AfterCall = call =>
+                settings.HttpClientFactory = new TestHttpClientFactory(this);
+                settings.AfterCall = call =>
                 {
                     CallLog.Add(call);
                 };
             };
             OpenStackNet.ResetDefaults();
-            OpenStackNet.Configure(setFlurlTestMode, configure);
+            OpenStackNet.Configure(setTestMode, configure);
         }
 
         /// <inheritdoc />

--- a/src/corelib/Testing/HttpTest.cs
+++ b/src/corelib/Testing/HttpTest.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using Flurl;
+using Flurl.Http;
 using Flurl.Http.Configuration;
+using Flurl.Http.Content;
 using OpenStack.Authentication;
 
 namespace OpenStack.Testing
@@ -31,6 +34,7 @@ namespace OpenStack.Testing
                     CallLog.Add(call);
                 };
             };
+            OpenStackNet.ResetDefaults();
             OpenStackNet.Configure(setFlurlTestMode, configure);
         }
 
@@ -39,6 +43,23 @@ namespace OpenStack.Testing
         {
             OpenStackNet.ResetDefaults();
             base.Dispose();
+        }
+
+        /// <inheritdoc />
+        public new HttpTest RespondWithJson(object data)
+        {
+            return RespondWithJson(200, data);
+        }
+
+        /// <inheritdoc />
+        public new HttpTest RespondWithJson(int status, object data)
+        {
+            ResponseQueue.Enqueue(new HttpResponseMessage
+            {
+                StatusCode = (HttpStatusCode)status,
+                Content = new CapturedJsonContent(OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(data))
+            });
+            return this;
         }
 
         class TestHttpClientFactory : IHttpClientFactory

--- a/src/corelib/corelib.nuspec
+++ b/src/corelib/corelib.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <group targetFramework="4.5">
         <dependency id="Newtonsoft.Json" version="[6.0.1,7.0)" />
-        <dependency id="Flurl.Http.Signed" version="[0.6.2.2015062601, 0.7)" />
+        <dependency id="Flurl.Http.Signed" version="[0.7.0, 0.8)" />
         <dependency id="Marvin.JsonPatch.Signed" version="[0.7.0]" />
       </group>
     </dependencies>

--- a/src/corelib/packages.config
+++ b/src/corelib/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl.Http.Signed" version="0.6.2.2015062601" targetFramework="net45" />
-  <package id="Flurl.Signed" version="1.0.8" targetFramework="net45" />
+  <package id="Flurl.Http.Signed" version="0.7.0" targetFramework="net45" />
+  <package id="Flurl.Signed" version="1.0.10" targetFramework="net45" />
+  <package id="ILMerge" version="2.14.1208" targetFramework="net4" />
   <package id="Marvin.JsonPatch.Signed" version="0.7.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="SimpleRESTServices" version="1.3.0.1-json6" targetFramework="net40" />
-  <package id="ILMerge" version="2.14.1208" targetFramework="net40" />
+  <package id="SimpleRESTServices" version="1.3.0.1-json6" targetFramework="net4" />
 </packages>

--- a/src/testing/integration/OpenStack.IntegrationTests.csproj
+++ b/src/testing/integration/OpenStack.IntegrationTests.csproj
@@ -48,12 +48,12 @@
     <AssemblyOriginatorKeyFile>..\..\..\build\keys\SDKTestingKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flurl, Version=1.0.8.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Signed.1.0.8\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
+    <Reference Include="Flurl, Version=1.0.10.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Signed.1.0.10\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Flurl.Http, Version=0.6.2.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.Signed.0.6.2.2015062601\lib\net45\Flurl.Http.dll</HintPath>
+    <Reference Include="Flurl.Http, Version=0.7.0.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Http.Signed.0.7.0\lib\net45\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib">

--- a/src/testing/integration/packages.config
+++ b/src/testing/integration/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl.Http.Signed" version="0.6.2.2015062601" targetFramework="net45" />
-  <package id="Flurl.Signed" version="1.0.8" targetFramework="net45" />
+  <package id="Flurl.Http.Signed" version="0.7.0" targetFramework="net45" />
+  <package id="Flurl.Signed" version="1.0.10" targetFramework="net45" />
   <package id="Marvin.JsonPatch.Signed" version="0.7.0" targetFramework="net45" />
-  <package id="Moq" version="4.0.10827" targetFramework="net40" />
+  <package id="Moq" version="4.0.10827" targetFramework="net4" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
-  <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net40" />
+  <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net4" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />

--- a/src/testing/unit/AuthenticationTests.cs
+++ b/src/testing/unit/AuthenticationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading.Tasks;
 using Flurl.Http;
 using OpenStack.ContentDeliveryNetworks.v1;
 using OpenStack.Testing;
@@ -9,7 +10,7 @@ namespace OpenStack
     public class AuthenticationTests
     {
         [Fact]
-        public async void When401UnauthorizedIsReturned_RetryRequest()
+        public async Task When401UnauthorizedIsReturned_RetryRequest()
         {
             using (var httpTest = new HttpTest())
             {
@@ -23,7 +24,7 @@ namespace OpenStack
         }
 
         [Fact]
-        public async void When401AuthenticationFailsMultipleTimes_ThrowException()
+        public async Task When401AuthenticationFailsMultipleTimes_ThrowException()
         {
             using (var httpTest = new HttpTest())
             {

--- a/src/testing/unit/Compute/v2_1/SecurityGroupTests.cs
+++ b/src/testing/unit/Compute/v2_1/SecurityGroupTests.cs
@@ -98,7 +98,7 @@ namespace OpenStack.Compute.v2_1
     },
     'id': '55d75417-37df-48e2-96aa-20ba53a82900'
 }}";
-            var result = JsonConvert.DeserializeObject<SecurityGroupRule>(JObject.Parse(json).ToString());
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<SecurityGroupRule>(JObject.Parse(json).ToString());
             Assert.Equal("0.0.0.0 / 24", result.CIDR);
         }
 

--- a/src/testing/unit/ContentDeliveryNetworks/v1/ServiceCacheTests.cs
+++ b/src/testing/unit/ContentDeliveryNetworks/v1/ServiceCacheTests.cs
@@ -12,7 +12,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         {
             var cache = new ServiceCache("cache", TimeSpan.FromSeconds(60));
             
-            var json = JsonConvert.SerializeObject(cache);
+            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(cache);
 
             var result = JObject.Parse(json);
             Assert.Equal(60, result.Value<double>("ttl"));
@@ -22,9 +22,9 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         public void DeserializeTimeToLiveFromSeconds()
         {
             var cache = new ServiceCache("cache", TimeSpan.FromSeconds(60));
-            var json = JsonConvert.SerializeObject(cache);
+            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(cache);
             
-            var result = JsonConvert.DeserializeObject<ServiceCache>(json);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ServiceCache>(json);
 
             Assert.Equal(60, result.TimeToLive.TotalSeconds);
         }

--- a/src/testing/unit/ContentDeliveryNetworks/v1/ServiceTests.cs
+++ b/src/testing/unit/ContentDeliveryNetworks/v1/ServiceTests.cs
@@ -32,7 +32,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
                 Items = {new Service {Id = "service-id"}},
                 Links = {new PageLink("next", "http://api.com/next")}
             };
-            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(services, Formatting.None);
+            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(services);
             Assert.Contains("\"services\"", json);
             Assert.DoesNotContain("\"service\"", json);
 
@@ -48,7 +48,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         public void SerializePageLink()
         {
             var link = new PageLink("next", "http://api.com/next");
-            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(link, Formatting.None);
+            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(link);
 
             var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<PageLink>(json);
             Assert.NotNull(result);

--- a/src/testing/unit/ContentDeliveryNetworks/v1/ServiceTests.cs
+++ b/src/testing/unit/ContentDeliveryNetworks/v1/ServiceTests.cs
@@ -171,7 +171,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         }
 
         [Fact]
-        public async void WaitForServiceDeployed_StopsWhenUserTokenIsCancelled()
+        public async Task WaitForServiceDeployed_StopsWhenUserTokenIsCancelled()
         {
             using (var httpTest = new HttpTest())
             {
@@ -184,7 +184,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         }
 
         [Fact]
-        public async void WaitForServiceDeployed_StopsWhenTimeoutIsReached()
+        public async Task WaitForServiceDeployed_StopsWhenTimeoutIsReached()
         {
             using (var httpTest = new HttpTest())
             {
@@ -207,7 +207,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         }
 
         [Fact]
-        public async void WaitForServiceDeleted_StopsWhenUserTokenIsCancelled()
+        public async Task WaitForServiceDeleted_StopsWhenUserTokenIsCancelled()
         {
             using (var httpTest = new HttpTest())
             {
@@ -220,7 +220,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         }
 
         [Fact]
-        public async void WaitForServiceDeleted_StopsWhenTimeoutIsReached()
+        public async Task WaitForServiceDeleted_StopsWhenTimeoutIsReached()
         {
             using (var httpTest = new HttpTest())
             {

--- a/src/testing/unit/ContentDeliveryNetworks/v1/ServiceTests.cs
+++ b/src/testing/unit/ContentDeliveryNetworks/v1/ServiceTests.cs
@@ -32,11 +32,11 @@ namespace OpenStack.ContentDeliveryNetworks.v1
                 Items = {new Service {Id = "service-id"}},
                 Links = {new PageLink("next", "http://api.com/next")}
             };
-            string json = JsonConvert.SerializeObject(services, Formatting.None);
+            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(services, Formatting.None);
             Assert.Contains("\"services\"", json);
             Assert.DoesNotContain("\"service\"", json);
 
-            var result = JsonConvert.DeserializeObject<ServiceCollection>(json);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ServiceCollection>(json);
             Assert.NotNull(result);
             Assert.Equal(1, result.Count());
             Assert.Equal(1, result.Items.Count());
@@ -48,9 +48,9 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         public void SerializePageLink()
         {
             var link = new PageLink("next", "http://api.com/next");
-            string json = JsonConvert.SerializeObject(link, Formatting.None);
+            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(link, Formatting.None);
 
-            var result = JsonConvert.DeserializeObject<PageLink>(json);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<PageLink>(json);
             Assert.NotNull(result);
             Assert.True(result.IsNextPage);
         }

--- a/src/testing/unit/IdentifierTests.cs
+++ b/src/testing/unit/IdentifierTests.cs
@@ -17,7 +17,7 @@ namespace OpenStack
             var rawId = Guid.NewGuid();
             var id = (Identifier)rawId;
 
-            var result = JsonConvert.SerializeObject(id);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(id);
 
             Assert.Equal(string.Format("\"{0}\"", rawId.ToString("D")), result);
         }
@@ -27,7 +27,7 @@ namespace OpenStack
         {
             var thing = new Thing {Id = Guid.NewGuid()};
 
-            var result = JsonConvert.SerializeObject(thing, Formatting.None);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing, Formatting.None);
 
             Assert.Equal(string.Format("{{\"Id\":\"{0}\"}}", thing.Id), result);
         }
@@ -37,8 +37,8 @@ namespace OpenStack
         {
             var id = new Identifier(Guid.NewGuid());
 
-            var json = JsonConvert.SerializeObject(id);
-            var result = JsonConvert.DeserializeObject<Identifier>(json);
+            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(id);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Identifier>(json);
 
             Assert.Equal(id, result);
         }

--- a/src/testing/unit/IdentifierTests.cs
+++ b/src/testing/unit/IdentifierTests.cs
@@ -27,7 +27,7 @@ namespace OpenStack
         {
             var thing = new Thing {Id = Guid.NewGuid()};
 
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing, Formatting.None);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing);
 
             Assert.Equal(string.Format("{{\"Id\":\"{0}\"}}", thing.Id), result);
         }

--- a/src/testing/unit/Networking/v2/DHCPOptionConverterTests.cs
+++ b/src/testing/unit/Networking/v2/DHCPOptionConverterTests.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using OpenStack.Networking.v2.Serialization;
-using OpenStack.Serialization;
 using Xunit;
 
 namespace OpenStack.Networking.v2
@@ -12,24 +10,27 @@ namespace OpenStack.Networking.v2
         [Fact]
         public void Serialize()
         {
-            var options = new Dictionary<string, string>
+            var input = new PortCreateDefinition(null)
             {
-                {"a", "stuff"},
-                {"b", "things"}
+                DHCPOptions =
+                {
+                    {"a", "stuff"},
+                    {"b", "things"}
+                }
             };
 
-            string result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(options, Formatting.None, new DHCPOptionsConverter());
+            string result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(input);
 
-            string expectedJson = JArray.Parse("[{'opt_name':'a','opt_value':'stuff'},{'opt_name':'b','opt_value':'things'}]").ToString(Formatting.None);
+            string expectedJson = JObject.Parse("{'port':{'extra_dhcp_opts':[{'opt_name':'a','opt_value':'stuff'},{'opt_name':'b','opt_value':'things'}]}}").ToString(Formatting.None);
             Assert.Equal(expectedJson, result);
         }
 
         [Fact]
         public void Deserialize()
         {
-            string json = JArray.Parse("[{'opt_name':'a','opt_value':'stuff'},{'opt_name':'b','opt_value':'things'}]").ToString(Formatting.None);
+            string json = JObject.Parse("{'port':{'extra_dhcp_opts':[{'opt_name':'a','opt_value':'stuff'},{'opt_name':'b','opt_value':'things'}]}}").ToString(Formatting.None);
 
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Dictionary<string, string>>(json, new DHCPOptionsConverter());
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<PortCreateDefinition>(json).DHCPOptions;
 
             Assert.NotNull(result);
             Assert.Equal(2, result.Count);
@@ -43,8 +44,6 @@ namespace OpenStack.Networking.v2
         [Fact]
         public void OpenStackNet_UsesDHCPOptionConverter()
         {
-            OpenStackNet.Configure();
-
             var port = new Port
             {
                 DHCPOptions = new Dictionary<string, string>

--- a/src/testing/unit/Networking/v2/DHCPOptionConverterTests.cs
+++ b/src/testing/unit/Networking/v2/DHCPOptionConverterTests.cs
@@ -18,7 +18,7 @@ namespace OpenStack.Networking.v2
                 {"b", "things"}
             };
 
-            string result = JsonConvert.SerializeObject(options, Formatting.None, new DHCPOptionsConverter());
+            string result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(options, Formatting.None, new DHCPOptionsConverter());
 
             string expectedJson = JArray.Parse("[{'opt_name':'a','opt_value':'stuff'},{'opt_name':'b','opt_value':'things'}]").ToString(Formatting.None);
             Assert.Equal(expectedJson, result);
@@ -29,7 +29,7 @@ namespace OpenStack.Networking.v2
         {
             string json = JArray.Parse("[{'opt_name':'a','opt_value':'stuff'},{'opt_name':'b','opt_value':'things'}]").ToString(Formatting.None);
 
-            var result = JsonConvert.DeserializeObject<Dictionary<string, string>>(json, new DHCPOptionsConverter());
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Dictionary<string, string>>(json, new DHCPOptionsConverter());
 
             Assert.NotNull(result);
             Assert.Equal(2, result.Count);
@@ -53,8 +53,8 @@ namespace OpenStack.Networking.v2
                 }
             };
 
-            var json = JsonConvert.SerializeObject(port);
-            var result = JsonConvert.DeserializeObject<Port>(json);
+            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(port);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Port>(json);
 
             Assert.NotNull(result.DHCPOptions);
             Assert.Equal(1, result.DHCPOptions.Count);

--- a/src/testing/unit/OpenStack.UnitTests.csproj
+++ b/src/testing/unit/OpenStack.UnitTests.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Stubs.cs" />
     <Compile Include="TestCategories.cs" />
     <Compile Include="ContentDeliveryNetworks\v1\ContentDeliveryNetworkServiceTests.cs" />
+    <Compile Include="XunitTraceListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\build\keys\SDKTestingKey.snk">

--- a/src/testing/unit/OpenStack.UnitTests.csproj
+++ b/src/testing/unit/OpenStack.UnitTests.csproj
@@ -47,12 +47,12 @@
     <AssemblyOriginatorKeyFile>..\..\..\build\keys\SDKTestingKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Flurl, Version=1.0.8.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Signed.1.0.8\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
+    <Reference Include="Flurl, Version=1.0.10.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Signed.1.0.10\lib\portable-net40+sl50+win+wpa81+wp80+MonoAndroid10+MonoTouch10\Flurl.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Flurl.Http, Version=0.6.2.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Flurl.Http.Signed.0.6.2.2015062601\lib\net45\Flurl.Http.dll</HintPath>
+    <Reference Include="Flurl.Http, Version=0.7.0.0, Culture=neutral, PublicKeyToken=1308302a96879dfb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Flurl.Http.Signed.0.7.0\lib\net45\Flurl.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Marvin.JsonPatch, Version=0.7.0.0, Culture=neutral, PublicKeyToken=686c63b2d045ab44, processorArchitecture=MSIL">

--- a/src/testing/unit/OpenStackNetTests.cs
+++ b/src/testing/unit/OpenStackNetTests.cs
@@ -18,14 +18,11 @@ namespace OpenStack
         {
             var testOutput = new XunitTraceListener(testLog);
             Trace.Listeners.Add(testOutput);
-
-            OpenStackNet.ResetDefaults();
         }
 
         public void Dispose()
         {
             OpenStackNet.ResetDefaults();
-            OpenStackNet.Configure();
         }
 
         [Fact]

--- a/src/testing/unit/OpenStackNetTests.cs
+++ b/src/testing/unit/OpenStackNetTests.cs
@@ -1,18 +1,24 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Flurl.Extensions;
 using Flurl.Http;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using OpenStack.Serialization;
 using OpenStack.Testing;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenStack
 {
     public class OpenStackNetTests : IDisposable
     {
-        public OpenStackNetTests()
+        public OpenStackNetTests(ITestOutputHelper testLog)
         {
+            var testOutput = new XunitTraceListener(testLog);
+            Trace.Listeners.Add(testOutput);
+
             OpenStackNet.ResetDefaults();
         }
 
@@ -23,31 +29,77 @@ namespace OpenStack
         }
 
         [Fact]
-        public void ResetDefaults_ResetsJsonNetConfiguration()
+        public void WhenConfigureIsCalled_GlobalFlurlConfiguration_IsNotAltered()
         {
-            OpenStackNet.Configure();
-            Assert.IsType<OpenStackContractResolver>(JsonSerializer.CreateDefault().ContractResolver);
-            OpenStackNet.ResetDefaults();
-            Assert.IsType<DefaultContractResolver>(JsonSerializer.CreateDefault().ContractResolver);
-        }
+            // User makes their own tweaks to Flurl
+            Action<HttpCall> customErrorHandler = call => Debug.WriteLine("I saw an erro!");
+            FlurlHttp.GlobalSettings.OnError = customErrorHandler;
 
-        [Fact]
-        public void ResetDefaults_ResetsFlurlConfiguration()
-        {
+            // We configure openstack.net
             OpenStackNet.Configure();
-            Assert.NotNull(FlurlHttp.GlobalSettings.BeforeCall);
-            OpenStackNet.ResetDefaults();
+
+            // We shouldn't have clobbered their settings
+            Assert.Null(FlurlHttp.GlobalSettings.AfterCall);
+            Assert.Null(FlurlHttp.GlobalSettings.AfterCallAsync);
             Assert.Null(FlurlHttp.GlobalSettings.BeforeCall);
+            Assert.Null(FlurlHttp.GlobalSettings.BeforeCallAsync);
+            Assert.Equal(customErrorHandler, FlurlHttp.GlobalSettings.OnError);
         }
 
         [Fact]
-        public async void UserAgentTest()
+        public void WhenResetDefaultsIsCalled_GlobalFlurlConfiguration_IsNotAltered()
+        {
+            // User makes their own tweaks to Flurl
+            Action<HttpCall> customErrorHandler = call => Debug.WriteLine("I saw an erro!");
+            FlurlHttp.GlobalSettings.OnError = customErrorHandler;
+
+            // We configure openstack.net
+            OpenStackNet.ResetDefaults();
+
+            // We shouldn't have clobbered their settings
+            Assert.Null(FlurlHttp.GlobalSettings.AfterCall);
+            Assert.Null(FlurlHttp.GlobalSettings.AfterCallAsync);
+            Assert.Null(FlurlHttp.GlobalSettings.BeforeCall);
+            Assert.Null(FlurlHttp.GlobalSettings.BeforeCallAsync);
+            Assert.Equal(customErrorHandler, FlurlHttp.GlobalSettings.OnError);
+        }
+
+        [Fact]
+        public void WhenResetDefaultsIsCalled_GlobalJsonConfiguration_IsNotAltered()
+        {
+            // User makes their own tweaks to the serialization
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings();
+
+            // We configure openstack.net
+            OpenStackNet.ResetDefaults();
+
+            // We shouldn't have clobbered their settings
+            var serializer = JsonSerializer.CreateDefault();
+            Assert.IsNotType<OpenStackContractResolver>(serializer.ContractResolver);
+        }
+
+        [Fact]
+        public void WhenConfigureIsCalled_GlobalJsonConfiguration_IsNotAltered()
+        {
+            // User makes their own tweaks to the serialization
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings();
+
+            // We configure openstack.net
+            OpenStackNet.Configure();
+
+            // We shouldn't have clobbered their settings
+            var serializer = JsonSerializer.CreateDefault();
+            Assert.IsNotType<OpenStackContractResolver>(serializer.ContractResolver);
+        }
+
+        [Fact]
+        public async Task UserAgentTest()
         {
             using (var httpTest = new HttpTest())
             {
                 OpenStackNet.Configure();
 
-                await "http://api.com".GetAsync();
+                await "http://api.com".PrepareRequest().GetAsync();
 
                 var userAgent = httpTest.CallLog[0].Request.Headers.UserAgent.ToString();
                 Assert.Contains("openstack.net", userAgent);
@@ -55,14 +107,14 @@ namespace OpenStack
         }
 
         [Fact]
-        public async void UserAgentOnlyListOnceTest()
+        public async Task UserAgentOnlyListOnceTest()
         {
             using (var httpTest = new HttpTest())
             {
                 OpenStackNet.Configure();
                 OpenStackNet.Configure(); // Duplicate call to Configure should be ignored
 
-                await "http://api.com".GetAsync();
+                await "http://api.com".PrepareRequest().GetAsync();
 
                 var userAgent = httpTest.CallLog[0].Request.Headers.UserAgent.ToString();
                 Assert.Contains("openstack.net", userAgent);
@@ -70,13 +122,12 @@ namespace OpenStack
         }
 
         [Fact]
-        public async void UserAgentWithApplicationSuffixTest()
+        public async Task UserAgentWithApplicationSuffixTest()
         {
-            using (var httpTest = new HttpTest())
+            using (var httpTest = new HttpTest(configure: options =>
+                    options.UserAgents.Add(new ProductInfoHeaderValue("(unittests)"))))
             {
-                OpenStackNet.Configure(configure: options => options.UserAgents.Add(new ProductInfoHeaderValue("(unittests)")));
-                
-                await "http://api.com".GetAsync();
+                await "http://api.com".PrepareRequest().GetAsync();
 
                 var userAgent = httpTest.CallLog[0].Request.Headers.UserAgent.ToString();
                 Assert.Contains("openstack.net", userAgent);

--- a/src/testing/unit/OpenStackNetTests.cs
+++ b/src/testing/unit/OpenStackNetTests.cs
@@ -9,6 +9,7 @@ using OpenStack.Serialization;
 using OpenStack.Testing;
 using Xunit;
 using Xunit.Abstractions;
+#pragma warning disable 618 // We can remove this once OpenStackNet.Configure() is made internal and obsolete is removed
 
 namespace OpenStack
 {

--- a/src/testing/unit/OpenStackNetTests.cs
+++ b/src/testing/unit/OpenStackNetTests.cs
@@ -35,9 +35,9 @@ namespace OpenStack
         public void ResetDefaults_ResetsFlurlConfiguration()
         {
             OpenStackNet.Configure();
-            Assert.NotNull(FlurlHttp.Configuration.BeforeCall);
+            Assert.NotNull(FlurlHttp.GlobalSettings.BeforeCall);
             OpenStackNet.ResetDefaults();
-            Assert.Null(FlurlHttp.Configuration.BeforeCall);
+            Assert.Null(FlurlHttp.GlobalSettings.BeforeCall);
         }
 
         [Fact]

--- a/src/testing/unit/Serialization/EmptyEnumerableTests.cs
+++ b/src/testing/unit/Serialization/EmptyEnumerableTests.cs
@@ -20,7 +20,6 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenDeserializingNullCollection_ItShouldUseAnEmptyCollection()
         {
-            OpenStackNet.Configure();
             var thing = new ExampleThing{Messages = null};
             string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing);
             Assert.DoesNotContain("messages", json);
@@ -34,7 +33,6 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenSerializingEmptyCollection_ItShouldBeIgnored()
         {
-            OpenStackNet.Configure();
             var thing = new ExampleThing { Messages = new List<string>() };
 
             string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing);

--- a/src/testing/unit/Serialization/EmptyEnumerableTests.cs
+++ b/src/testing/unit/Serialization/EmptyEnumerableTests.cs
@@ -22,10 +22,10 @@ namespace OpenStack.Serialization
         {
             OpenStackNet.Configure();
             var thing = new ExampleThing{Messages = null};
-            string json = JsonConvert.SerializeObject(thing);
+            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing);
             Assert.DoesNotContain("messages", json);
 
-            var result = JsonConvert.DeserializeObject<ExampleThing>(json);
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ExampleThing>(json);
 
             Assert.NotNull(result.Messages);
             Assert.Empty(result.Messages);
@@ -37,7 +37,7 @@ namespace OpenStack.Serialization
             OpenStackNet.Configure();
             var thing = new ExampleThing { Messages = new List<string>() };
 
-            string json = JsonConvert.SerializeObject(thing);
+            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing);
 
             Assert.DoesNotContain("messages", json);
         }

--- a/src/testing/unit/Serialization/RootWrapperConverterTests.cs
+++ b/src/testing/unit/Serialization/RootWrapperConverterTests.cs
@@ -19,12 +19,7 @@ namespace OpenStack.Serialization
         class ThingCollection : List<Thing>
         {
         }
-
-        public RootWrapperConverterTests()
-        {
-            OpenStackNet.Configure();            
-        }
-
+        
         [Fact]
         public void Serialize()
         {

--- a/src/testing/unit/Serialization/RootWrapperConverterTests.cs
+++ b/src/testing/unit/Serialization/RootWrapperConverterTests.cs
@@ -28,7 +28,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void Serialize()
         {
-            var json = JsonConvert.SerializeObject(new Thing());
+            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(new Thing());
             
             var jsonObj = JObject.Parse(json);
             JProperty rootProperty = jsonObj.Properties().FirstOrDefault();
@@ -39,15 +39,15 @@ namespace OpenStack.Serialization
         [Fact]
         public void Deserialize()
         {
-            var json = JsonConvert.SerializeObject(new Thing {Id = "thing-id"});
-            var thing = JsonConvert.DeserializeObject<Thing>(json);
+            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(new Thing {Id = "thing-id"});
+            var thing = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Thing>(json);
             Assert.Equal("thing-id", thing.Id);
         }
 
         [Fact]
         public void SerializeWhenNotRoot()
         {
-            var json = JsonConvert.SerializeObject(new List<Thing>{ new Thing() });
+            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(new List<Thing>{ new Thing() });
 
             Assert.DoesNotContain("\"thing\"", json);
         }
@@ -55,7 +55,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void SerializeWhenNested()
         {
-            var json = JsonConvert.SerializeObject(new ThingCollection { new Thing() });
+            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(new ThingCollection { new Thing() });
 
             Assert.DoesNotContain("\"thing\"", json);
         }
@@ -64,7 +64,7 @@ namespace OpenStack.Serialization
         public void DeserializeWhenNotRoot()
         {
             var json = JArray.Parse("[{'id':'thing-id'}]").ToString();
-            var things = JsonConvert.DeserializeObject<List<Thing>>(json);
+            var things = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<List<Thing>>(json);
             Assert.Equal(1, things.Count);
             Assert.Equal("thing-id", things[0].Id);
         }
@@ -73,7 +73,7 @@ namespace OpenStack.Serialization
         public void DeserializeWhenNested()
         {
             var json = JObject.Parse("{'things':[{'id':'thing-id'}]}").ToString();
-            var things = JsonConvert.DeserializeObject<ThingCollection>(json);
+            var things = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ThingCollection>(json);
             Assert.NotNull(things);
             Assert.Equal(1, things.Count);
             Assert.Equal("thing-id", things[0].Id);
@@ -83,7 +83,7 @@ namespace OpenStack.Serialization
         public void ShouldIgnoreUnexpectedRootProperties()
         {
             var json = JObject.Parse("{'links': [{'name': 'next', 'link': 'http://nextlink'}], 'thing': {'id': 'thing-id'}}").ToString();
-            var thing = JsonConvert.DeserializeObject<Thing>(json);
+            var thing = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Thing>(json);
             Assert.NotNull(thing);
             Assert.Equal("thing-id", thing.Id);
         }

--- a/src/testing/unit/Serialization/TolerantEnumConverterTests.cs
+++ b/src/testing/unit/Serialization/TolerantEnumConverterTests.cs
@@ -25,7 +25,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenValueIsRecognized_MatchToValue()
         {
-            var result = JsonConvert.DeserializeObject<ThingStatus>("\"ACTIVE\"");
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ThingStatus>("\"ACTIVE\"");
 
             Assert.Equal(ThingStatus.Active, result);
         }
@@ -33,7 +33,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenAttributedValueIsRecognized_MatchToValue()
         {
-            var result = JsonConvert.DeserializeObject<ThingStatus>("\"REMOVE_FAILED\"");
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ThingStatus>("\"REMOVE_FAILED\"");
 
             Assert.Equal(ThingStatus.RemoveFailed, result);
         }
@@ -41,7 +41,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenValueIsUnrecognized_MatchToUnknownValue()
         {
-            var result = JsonConvert.DeserializeObject<ThingStatus>("\"bad-enum-value\"");
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ThingStatus>("\"bad-enum-value\"");
 
             Assert.Equal(ThingStatus.Unknown, result);
         }
@@ -49,7 +49,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenValueIsUnrecognized_AndUnknownIsNotPresent_MatchToFirstValue()
         {
-            var result = JsonConvert.DeserializeObject<StuffStatus>("\"bad-enum-value\"");
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<StuffStatus>("\"bad-enum-value\"");
 
             Assert.Equal(StuffStatus.Missing, result);
         }
@@ -57,7 +57,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenValueIsUnrecognized_AndDestinationIsNullable_UseNull()
         {
-            var result = JsonConvert.DeserializeObject<StuffStatus?>("\"bad-enum-value\"");
+            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<StuffStatus?>("\"bad-enum-value\"");
 
             Assert.Null(result);
         }

--- a/src/testing/unit/Stubs.cs
+++ b/src/testing/unit/Stubs.cs
@@ -21,7 +21,6 @@ namespace OpenStack
         public static Mock<IAuthenticationProvider> CreateAuthenticationProvider()
         {
             var stub = new Mock<IAuthenticationProvider>();
-            OpenStackNet.Configure();
 
             stub.Setup(provider => provider.GetToken(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult("mock-token"));

--- a/src/testing/unit/XunitTraceListener.cs
+++ b/src/testing/unit/XunitTraceListener.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+using Xunit.Abstractions;
+
+namespace OpenStack
+{
+    public class XunitTraceListener : TraceListener
+    {
+        private readonly ITestOutputHelper _testLog;
+
+        public XunitTraceListener(ITestOutputHelper testLog)
+        {
+            _testLog = testLog;
+        }
+
+        public override void Write(string message)
+        {
+            if (message.StartsWith(OpenStackNet.Tracing.Http.Name))
+                return;
+
+            TryLog(message);
+        }
+
+        public override void WriteLine(string message)
+        {
+            TryLog(message);
+        }
+
+        private void TryLog(string message)
+        {
+            try
+            {
+                _testLog.WriteLine(message);
+            }
+            catch (InvalidOperationException)
+            {
+                // Unable to log to xunit because it thinks no test is active...
+            }
+        }
+    }
+}

--- a/src/testing/unit/packages.config
+++ b/src/testing/unit/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Flurl.Http.Signed" version="0.6.2.2015062601" targetFramework="net45" />
-  <package id="Flurl.Signed" version="1.0.8" targetFramework="net45" />
+  <package id="Flurl.Http.Signed" version="0.7.0" targetFramework="net45" />
+  <package id="Flurl.Signed" version="1.0.10" targetFramework="net45" />
   <package id="Marvin.JsonPatch.Signed" version="0.7.0" targetFramework="net45" />
-  <package id="Moq" version="4.0.10827" targetFramework="net40" />
+  <package id="Moq" version="4.0.10827" targetFramework="net4" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net40" />
+  <package id="SimpleRESTServices" version="1.3.0.1" targetFramework="net4" />
   <package id="xunit" version="2.0.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />


### PR DESCRIPTION
Flurl.Http 0.7 gives us the ability to use a custom Flurl instance for just our library without impacting the application's use of Flurl or Json.NET.

Fixed #551.