### PR TITLE
Fix access token deserialization for vanilla openstack

### DIFF
--- a/src/corelib/ContentDeliveryNetworks/v1/ServiceOperationFailedException.cs
+++ b/src/corelib/ContentDeliveryNetworks/v1/ServiceOperationFailedException.cs
@@ -27,7 +27,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         /// <param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext" /> that contains contextual information about the source or destination.</param>
         private ServiceOperationFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
-            Errors = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<IEnumerable<ServiceError>>(info.GetString("service_errors"));
+            Errors = OpenStackNet.Deserialize<IEnumerable<ServiceError>>(info.GetString("service_errors"));
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             // ReSharper disable once ExceptionNotDocumented
-            info.AddValue("service_errors", OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(Errors));
+            info.AddValue("service_errors", OpenStackNet.Serialize(Errors));
             base.GetObjectData(info, context);
         }
     }

--- a/src/corelib/Core/Providers/OpenStackIdentityProvider.cs
+++ b/src/corelib/Core/Providers/OpenStackIdentityProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 using OpenStack;
 using OpenStack.Authentication;
 
@@ -109,11 +110,12 @@ namespace net.openstack.Core.Providers
                     if (response == null || response.Data == null)
                         return null;
 
-                    JToken userAccessObject = response.Data["access"];
-                    if (userAccessObject == null)
+                    // The defalut json serialization is helpfully formatting the expires date string. Use our custom serializer for this part to prevent chaos of timezone proportions.
+                    var rawJson = response.Data["access"]?.ToString(Formatting.None);
+                    if (rawJson == null)
                         return null;
 
-                    UserAccess access = userAccessObject.ToObject<UserAccess>();
+                    UserAccess access = OpenStackNet.Deserialize<UserAccess>(rawJson);
                     if (access == null || access.Token == null)
                         return null;
 

--- a/src/corelib/OpenStackNet.cs
+++ b/src/corelib/OpenStackNet.cs
@@ -90,6 +90,26 @@ namespace OpenStack
         }
 
         /// <summary>
+        /// Deserializes an object from a json string representation.
+        /// </summary>
+        /// <typeparam name="T">The object type.</typeparam>
+        /// <param name="json">The json string.</param>
+        public static T Deserialize<T>(string json)
+        {
+            return Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<T>(json);
+        }
+
+        /// <summary>
+        /// Serializes an object to a json string representation
+        /// </summary>
+        /// <param name="obj">The object.</param>
+        /// <returns>The json string representation of the object.</returns>
+        public static string Serialize(object obj)
+        {
+            return Configuration.FlurlHttpSettings.JsonSerializer.Serialize(obj);
+        }
+
+        /// <summary>
         /// Provides global point for programmatically configuraing tracing
         /// </summary>
         public static class Tracing

--- a/src/corelib/Testing/HttpTest.cs
+++ b/src/corelib/Testing/HttpTest.cs
@@ -54,7 +54,7 @@ namespace OpenStack.Testing
             ResponseQueue.Enqueue(new HttpResponseMessage
             {
                 StatusCode = (HttpStatusCode)status,
-                Content = new CapturedJsonContent(OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(data))
+                Content = new CapturedJsonContent(OpenStackNet.Serialize(data))
             });
             return this;
         }

--- a/src/testing/unit/Compute/v2_1/KeyPairTests.cs
+++ b/src/testing/unit/Compute/v2_1/KeyPairTests.cs
@@ -43,7 +43,7 @@ namespace OpenStack.Compute.v2_1
   ]
 }").ToString();
 
-            var results = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<KeyPairSummaryCollection>(json);
+            var results = OpenStackNet.Deserialize<KeyPairSummaryCollection>(json);
             Assert.NotNull(results);
             Assert.Equal(2, results.Count());
             var result = results.First();

--- a/src/testing/unit/Compute/v2_1/SecurityGroupTests.cs
+++ b/src/testing/unit/Compute/v2_1/SecurityGroupTests.cs
@@ -98,7 +98,7 @@ namespace OpenStack.Compute.v2_1
     },
     'id': '55d75417-37df-48e2-96aa-20ba53a82900'
 }}";
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<SecurityGroupRule>(JObject.Parse(json).ToString());
+            var result = OpenStackNet.Deserialize<SecurityGroupRule>(JObject.Parse(json).ToString());
             Assert.Equal("0.0.0.0 / 24", result.CIDR);
         }
 

--- a/src/testing/unit/Compute/v2_1/ServerTests.cs
+++ b/src/testing/unit/Compute/v2_1/ServerTests.cs
@@ -29,7 +29,7 @@ namespace OpenStack.Compute.v2_1
             server.SchedulerHints = new SchedulerHints();
             server.SchedulerHints.Add("group", "groupId");
 
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(server);
+            var json = OpenStackNet.Serialize(server);
             Assert.Equal(expectedJson, json);
         }
 
@@ -40,7 +40,7 @@ namespace OpenStack.Compute.v2_1
                 .ToString(Formatting.None);
             var server = new ServerCreateDefinition("name", Guid.Empty, Guid.Empty);
 
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(server);
+            var json = OpenStackNet.Serialize(server);
             Assert.Equal(expectedJson, json);
         }
 

--- a/src/testing/unit/Compute/v2_1/VolumeTests.cs
+++ b/src/testing/unit/Compute/v2_1/VolumeTests.cs
@@ -24,7 +24,7 @@ namespace OpenStack.Compute.v2_1
         public void DeserializeVolumeWithEmptyAttachment()
         {
             var json = JObject.Parse(@"{'volume': {'attachments': [{}]}}").ToString();
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Volume>(json);
+            var result = OpenStackNet.Deserialize<Volume>(json);
             Assert.Empty(result.Attachments);
         }
 

--- a/src/testing/unit/ContentDeliveryNetworks/v1/ServiceCacheTests.cs
+++ b/src/testing/unit/ContentDeliveryNetworks/v1/ServiceCacheTests.cs
@@ -12,7 +12,7 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         {
             var cache = new ServiceCache("cache", TimeSpan.FromSeconds(60));
             
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(cache);
+            var json = OpenStackNet.Serialize(cache);
 
             var result = JObject.Parse(json);
             Assert.Equal(60, result.Value<double>("ttl"));
@@ -22,9 +22,9 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         public void DeserializeTimeToLiveFromSeconds()
         {
             var cache = new ServiceCache("cache", TimeSpan.FromSeconds(60));
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(cache);
+            var json = OpenStackNet.Serialize(cache);
             
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ServiceCache>(json);
+            var result = OpenStackNet.Deserialize<ServiceCache>(json);
 
             Assert.Equal(60, result.TimeToLive.TotalSeconds);
         }

--- a/src/testing/unit/ContentDeliveryNetworks/v1/ServiceTests.cs
+++ b/src/testing/unit/ContentDeliveryNetworks/v1/ServiceTests.cs
@@ -32,11 +32,11 @@ namespace OpenStack.ContentDeliveryNetworks.v1
                 Items = {new Service {Id = "service-id"}},
                 Links = {new PageLink("next", "http://api.com/next")}
             };
-            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(services);
+            string json = OpenStackNet.Serialize(services);
             Assert.Contains("\"services\"", json);
             Assert.DoesNotContain("\"service\"", json);
 
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ServiceCollection>(json);
+            var result = OpenStackNet.Deserialize<ServiceCollection>(json);
             Assert.NotNull(result);
             Assert.Equal(1, result.Count());
             Assert.Equal(1, result.Items.Count());
@@ -48,9 +48,9 @@ namespace OpenStack.ContentDeliveryNetworks.v1
         public void SerializePageLink()
         {
             var link = new PageLink("next", "http://api.com/next");
-            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(link);
+            string json = OpenStackNet.Serialize(link);
 
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<PageLink>(json);
+            var result = OpenStackNet.Deserialize<PageLink>(json);
             Assert.NotNull(result);
             Assert.True(result.IsNextPage);
         }

--- a/src/testing/unit/IdentifierTests.cs
+++ b/src/testing/unit/IdentifierTests.cs
@@ -17,7 +17,7 @@ namespace OpenStack
             var rawId = Guid.NewGuid();
             var id = (Identifier)rawId;
 
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(id);
+            var result = OpenStackNet.Serialize(id);
 
             Assert.Equal(string.Format("\"{0}\"", rawId.ToString("D")), result);
         }
@@ -27,7 +27,7 @@ namespace OpenStack
         {
             var thing = new Thing {Id = Guid.NewGuid()};
 
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing);
+            var result = OpenStackNet.Serialize(thing);
 
             Assert.Equal(string.Format("{{\"Id\":\"{0}\"}}", thing.Id), result);
         }
@@ -37,8 +37,8 @@ namespace OpenStack
         {
             var id = new Identifier(Guid.NewGuid());
 
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(id);
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Identifier>(json);
+            var json = OpenStackNet.Serialize(id);
+            var result = OpenStackNet.Deserialize<Identifier>(json);
 
             Assert.Equal(id, result);
         }

--- a/src/testing/unit/Networking/v2/DHCPOptionConverterTests.cs
+++ b/src/testing/unit/Networking/v2/DHCPOptionConverterTests.cs
@@ -19,7 +19,7 @@ namespace OpenStack.Networking.v2
                 }
             };
 
-            string result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(input);
+            string result = OpenStackNet.Serialize(input);
 
             string expectedJson = JObject.Parse("{'port':{'extra_dhcp_opts':[{'opt_name':'a','opt_value':'stuff'},{'opt_name':'b','opt_value':'things'}]}}").ToString(Formatting.None);
             Assert.Equal(expectedJson, result);
@@ -30,7 +30,7 @@ namespace OpenStack.Networking.v2
         {
             string json = JObject.Parse("{'port':{'extra_dhcp_opts':[{'opt_name':'a','opt_value':'stuff'},{'opt_name':'b','opt_value':'things'}]}}").ToString(Formatting.None);
 
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<PortCreateDefinition>(json).DHCPOptions;
+            var result = OpenStackNet.Deserialize<PortCreateDefinition>(json).DHCPOptions;
 
             Assert.NotNull(result);
             Assert.Equal(2, result.Count);
@@ -52,8 +52,8 @@ namespace OpenStack.Networking.v2
                 }
             };
 
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(port);
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Port>(json);
+            var json = OpenStackNet.Serialize(port);
+            var result = OpenStackNet.Deserialize<Port>(json);
 
             Assert.NotNull(result.DHCPOptions);
             Assert.Equal(1, result.DHCPOptions.Count);

--- a/src/testing/unit/Serialization/EmptyEnumerableTests.cs
+++ b/src/testing/unit/Serialization/EmptyEnumerableTests.cs
@@ -21,10 +21,10 @@ namespace OpenStack.Serialization
         public void WhenDeserializingNullCollection_ItShouldUseAnEmptyCollection()
         {
             var thing = new ExampleThing{Messages = null};
-            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing);
+            string json = OpenStackNet.Serialize(thing);
             Assert.DoesNotContain("messages", json);
 
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ExampleThing>(json);
+            var result = OpenStackNet.Deserialize<ExampleThing>(json);
 
             Assert.NotNull(result.Messages);
             Assert.Empty(result.Messages);
@@ -35,7 +35,7 @@ namespace OpenStack.Serialization
         {
             var thing = new ExampleThing { Messages = new List<string>() };
 
-            string json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(thing);
+            string json = OpenStackNet.Serialize(thing);
 
             Assert.DoesNotContain("messages", json);
         }

--- a/src/testing/unit/Serialization/RootWrapperConverterTests.cs
+++ b/src/testing/unit/Serialization/RootWrapperConverterTests.cs
@@ -23,7 +23,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void Serialize()
         {
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(new Thing());
+            var json = OpenStackNet.Serialize(new Thing());
             
             var jsonObj = JObject.Parse(json);
             JProperty rootProperty = jsonObj.Properties().FirstOrDefault();
@@ -34,15 +34,15 @@ namespace OpenStack.Serialization
         [Fact]
         public void Deserialize()
         {
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(new Thing {Id = "thing-id"});
-            var thing = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Thing>(json);
+            var json = OpenStackNet.Serialize(new Thing {Id = "thing-id"});
+            var thing = OpenStackNet.Deserialize<Thing>(json);
             Assert.Equal("thing-id", thing.Id);
         }
 
         [Fact]
         public void SerializeWhenNotRoot()
         {
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(new List<Thing>{ new Thing() });
+            var json = OpenStackNet.Serialize(new List<Thing>{ new Thing() });
 
             Assert.DoesNotContain("\"thing\"", json);
         }
@@ -50,7 +50,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void SerializeWhenNested()
         {
-            var json = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Serialize(new ThingCollection { new Thing() });
+            var json = OpenStackNet.Serialize(new ThingCollection { new Thing() });
 
             Assert.DoesNotContain("\"thing\"", json);
         }
@@ -59,7 +59,7 @@ namespace OpenStack.Serialization
         public void DeserializeWhenNotRoot()
         {
             var json = JArray.Parse("[{'id':'thing-id'}]").ToString();
-            var things = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<List<Thing>>(json);
+            var things = OpenStackNet.Deserialize<List<Thing>>(json);
             Assert.Equal(1, things.Count);
             Assert.Equal("thing-id", things[0].Id);
         }
@@ -68,7 +68,7 @@ namespace OpenStack.Serialization
         public void DeserializeWhenNested()
         {
             var json = JObject.Parse("{'things':[{'id':'thing-id'}]}").ToString();
-            var things = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ThingCollection>(json);
+            var things = OpenStackNet.Deserialize<ThingCollection>(json);
             Assert.NotNull(things);
             Assert.Equal(1, things.Count);
             Assert.Equal("thing-id", things[0].Id);
@@ -78,7 +78,7 @@ namespace OpenStack.Serialization
         public void ShouldIgnoreUnexpectedRootProperties()
         {
             var json = JObject.Parse("{'links': [{'name': 'next', 'link': 'http://nextlink'}], 'thing': {'id': 'thing-id'}}").ToString();
-            var thing = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<Thing>(json);
+            var thing = OpenStackNet.Deserialize<Thing>(json);
             Assert.NotNull(thing);
             Assert.Equal("thing-id", thing.Id);
         }

--- a/src/testing/unit/Serialization/TolerantEnumConverterTests.cs
+++ b/src/testing/unit/Serialization/TolerantEnumConverterTests.cs
@@ -25,7 +25,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenValueIsRecognized_MatchToValue()
         {
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ThingStatus>("\"ACTIVE\"");
+            var result = OpenStackNet.Deserialize<ThingStatus>("\"ACTIVE\"");
 
             Assert.Equal(ThingStatus.Active, result);
         }
@@ -33,7 +33,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenAttributedValueIsRecognized_MatchToValue()
         {
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ThingStatus>("\"REMOVE_FAILED\"");
+            var result = OpenStackNet.Deserialize<ThingStatus>("\"REMOVE_FAILED\"");
 
             Assert.Equal(ThingStatus.RemoveFailed, result);
         }
@@ -41,7 +41,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenValueIsUnrecognized_MatchToUnknownValue()
         {
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<ThingStatus>("\"bad-enum-value\"");
+            var result = OpenStackNet.Deserialize<ThingStatus>("\"bad-enum-value\"");
 
             Assert.Equal(ThingStatus.Unknown, result);
         }
@@ -49,7 +49,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenValueIsUnrecognized_AndUnknownIsNotPresent_MatchToFirstValue()
         {
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<StuffStatus>("\"bad-enum-value\"");
+            var result = OpenStackNet.Deserialize<StuffStatus>("\"bad-enum-value\"");
 
             Assert.Equal(StuffStatus.Missing, result);
         }
@@ -57,7 +57,7 @@ namespace OpenStack.Serialization
         [Fact]
         public void WhenValueIsUnrecognized_AndDestinationIsNullable_UseNull()
         {
-            var result = OpenStackNet.Configuration.FlurlHttpSettings.JsonSerializer.Deserialize<StuffStatus?>("\"bad-enum-value\"");
+            var result = OpenStackNet.Deserialize<StuffStatus?>("\"bad-enum-value\"");
 
             Assert.Null(result);
         }


### PR DESCRIPTION
The default json.net serializer will helpfully reformat strings that appear to be date time strings for you, even when the destination property is a string. Use the preconfigured jsonserializer which has this disabled, to preserve the expires string as-is.

Fixes #630 