### PR TITLE
Allow Newtonsoft.Json 10.x

### DIFF
--- a/src/corelib/corelib.nuspec
+++ b/src/corelib/corelib.nuspec
@@ -15,7 +15,7 @@
     <tags>openstack</tags>
     <dependencies>
       <group targetFramework="4.5">
-        <dependency id="Newtonsoft.Json" version="[6.0.1,10.0)" />
+        <dependency id="Newtonsoft.Json" version="6.0.1" />
         <dependency id="Flurl.Http.Signed" version="[0.7.0, 0.8)" />
         <dependency id="Marvin.JsonPatch.Signed" version="[0.7.0]" />
       </group>


### PR DESCRIPTION
I think it is best to just remove the maximum version number for Newtonsoft.Json. Most other NuGet packages I have looked at use this approach with Newtonsoft.Json. 

I'm also happy to change the range to be "[6.0.1,11.0)", if that's what the maintainers would prefer. But since this project doesn't seem very actively maintained, I think just removing the max version will allow more people to continue to use it without this being a recurring issue.